### PR TITLE
[chore] SwiftLint 설정 파일을 추가했습니다.

### DIFF
--- a/SniffMeet/SniffMeet/.swiftlint.yml
+++ b/SniffMeet/SniffMeet/.swiftlint.yml
@@ -26,10 +26,10 @@ custom_rules:
     # 타입 바디에 static 멤버 금지
     static_in_extension:
         included: ".*\\.swift"
-        name: "Static properties should be declared in an extension"
+        name: "Declare Static Members in Extensions"
         regex: '(class|struct|enum)\s+\w+\s*\{[^}]*?\s*static\s+(var|let|func)\s+\w+'
         severity: warning
-        message: "Static properties should be declared inside an extension."
+        message: "Static members should be declared inside an extension."
     # return 생략할 수 있으면 생략하기
     implicit_return:
         included: ".*\\.swift"

--- a/SniffMeet/SniffMeet/.swiftlint.yml
+++ b/SniffMeet/SniffMeet/.swiftlint.yml
@@ -4,16 +4,25 @@ disabled_rules:
 
 opt_in_rules:
     - sorted_imports
+    - empty_count
+    - missing_docs
 
 analyzer_rules:
     - unused_import
     - unused_declaration
 
+reporter: "xcode"
 line_length:
     warning: 100
     # ignores_urls: true
     # ignores_comments: true
-
+large_tuple:
+    warning: 3
+nesting:
+    type_level:
+        warning: 3
+force_cast: warning
+force_try: warning
 custom_rules:
     # 함수 네이밍에 get prefix 금지
     no_get_prefix:
@@ -39,3 +48,5 @@ custom_rules:
         message: "Use implicit return by omitting 'return' when possible."
 
 excluded:
+    - SniffMeet/AppDelegate.swift
+    - SniffMeet/SceneDelegate.swift

--- a/SniffMeet/SniffMeet/.swiftlint.yml
+++ b/SniffMeet/SniffMeet/.swiftlint.yml
@@ -1,0 +1,41 @@
+# HGD SwiftLint Rules
+
+disabled_rules:
+
+opt_in_rules:
+    - sorted_imports
+
+analyzer_rules:
+    - unused_import
+    - unused_declaration
+
+line_length:
+    warning: 100
+    # ignores_urls: true
+    # ignores_comments: true
+
+custom_rules:
+    # 함수 네이밍에 get prefix 금지
+    no_get_prefix:
+        included: ".*\\.swift"
+        name: "Avoid 'get' Prefix"
+        regex: 'func get[A-Z].*'
+        match_kind: [function_decl]
+        severity: warning
+        message: "Do not use 'get' as a function prefix."
+    # 타입 바디에 static 멤버 금지
+    static_in_extension:
+        included: ".*\\.swift"
+        name: "Static properties should be declared in an extension"
+        regex: '(class|struct|enum)\s+\w+\s*\{[^}]*?\s*static\s+(var|let|func)\s+\w+'
+        severity: warning
+        message: "Static properties should be declared inside an extension."
+    # return 생략할 수 있으면 생략하기
+    implicit_return:
+        included: ".*\\.swift"
+        name: "Use implicit return when possible"
+        regex: '\{\s*[^\{\}\n]*\n?return\s+[^\s\{\}\n]+\n?\s*\}'
+        severity: warning
+        message: "Use implicit return by omitting 'return' when possible."
+
+excluded:


### PR DESCRIPTION
### 🔖  Issue Number

close #11

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [X]  커스텀 룰에 맞춰서 `.swiftlint.yml` 파일 추가
    - [X]  함수 네이밍에 'get'을 prefix로 사용하면 경고 띄우기
    - [X]  타입의 바디에 `static` 멤버 금지하기
    - [X]  return 생략할 수 있으면 생략하기

<img width="1145" alt="Screenshot 2024-11-06 at 2 42 42 AM" src="https://github.com/user-attachments/assets/25dc1bbf-32bf-4746-90e1-ace42c0a119e">


### 📝 PR 특이 사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 스태틱 프로퍼티만 막는건가요? 일단 코드에선 스태틱 멤버 모두 막도록 설정했습니다.
```yml
# var, let, func 모두 막기
'(class|struct|enum)\s+\w+\s*\{[^}]*?\s*static\s+(var|let|func)\s+\w+'
```
- 프로젝트의 `AppDelegate.swift` 파일의 코드가 `return` 생략하는 컨벤션과 현재 맞지 않습니다. 수정이 필요해보입니다.
<img width="983" alt="Screenshot 2024-11-06 at 3 11 06 AM" src="https://github.com/user-attachments/assets/45bba857-58ed-492b-acb2-e5d193ffb580">

- `lineLength`에 코멘트로 처리한 부분이 있는데요. 각각 url이랑 코멘트는 예외로 둘 수 있는 부분인데 나중에 필요할 수도 있어 보여서 일단은 적어놓기만 하고 코멘트로 처리해서 적용은 안되도록 해놨습니다.
```yml
line_length:
    warning: 100
    # ignores_urls: true
    # ignores_comments: true
```
- Switch-case 구문에서의 `return` 생략을 어떻게 처리해야 할지 고민이 많습니다...

### 👻 레퍼런스
- [SniffMEET GitHub 컨벤션](https://github.com/boostcampwm-2024/iOS03-SniffMeet/wiki/Github-%EC%BB%A8%EB%B2%A4%EC%85%98)