### PR TITLE
[design] 프로필 이미지 및 닉네임 입력 화면 생성

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -7,14 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A288A63D2CDC595000D11C34 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A288A63C2CDC595000D11C34 /* .swiftlint.yml */; };
-		320043702CDC9A0D00D08B6D /* InputTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200436F2CDC99F900D08B6D /* InputTextField.swift */; };
-		320043722CDC9E5F00D08B6D /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043712CDC9E5F00D08B6D /* TestViewController.swift */; };
-		320043762CDCA18E00D08B6D /* Extension + Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043752CDCA17E00D08B6D /* Extension + Navigation.swift */; };
-		320043782CDCA49100D08B6D /* KeywordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043772CDCA48900D08B6D /* KeywordView.swift */; };
-		3200437C2CDCA6F300D08B6D /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200437B2CDCA6F300D08B6D /* TestViewController.swift */; };
-		A2C844D12CDBE1E5007F2970 /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C844D02CDBE1E5007F2970 /* PrimaryButton.swift */; };
-		A2C844D72CDBEF8B007F2970 /* KeywordButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C844D62CDBEF8B007F2970 /* KeywordButton.swift */; };
+		320043702CDC9A0D00D08B6D /* (null) in Sources */ = {isa = PBXBuildFile; };
+		320043722CDC9E5F00D08B6D /* (null) in Sources */ = {isa = PBXBuildFile; };
+		320043762CDCA18E00D08B6D /* (null) in Sources */ = {isa = PBXBuildFile; };
+		320043782CDCA49100D08B6D /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3200437C2CDCA6F300D08B6D /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3200438B2CDF3BEF00D08B6D /* ProfileSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438A2CDF3BE900D08B6D /* ProfileSetupView.swift */; };
+		320043912CDF3D7F00D08B6D /* KeywordButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438E2CDF3D7F00D08B6D /* KeywordButton.swift */; };
+		320043922CDF3D7F00D08B6D /* InputTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438D2CDF3D7F00D08B6D /* InputTextField.swift */; };
+		320043932CDF3D7F00D08B6D /* KeywordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438F2CDF3D7F00D08B6D /* KeywordView.swift */; };
+		320043942CDF3D7F00D08B6D /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043902CDF3D7F00D08B6D /* PrimaryButton.swift */; };
+		320043952CDF3D7F00D08B6D /* Extension + Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438C2CDF3D7F00D08B6D /* Extension + Navigation.swift */; };
+		320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043962CDF493600D08B6D /* Extension + UIView.swift */; };
+		A288A63D2CDC595000D11C34 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		A2C844D12CDBE1E5007F2970 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		A2C844D72CDBEF8B007F2970 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		FD3A033F2CD8CF460047B7ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FD3A03392CD8CF460047B7ED /* Assets.xcassets */; };
 		FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */; };
 		FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A03382CD8CF460047B7ED /* AppDelegate.swift */; };
@@ -22,6 +29,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3200438A2CDF3BE900D08B6D /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
+		3200438C2CDF3D7F00D08B6D /* Extension + Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Navigation.swift"; sourceTree = "<group>"; };
+		3200438D2CDF3D7F00D08B6D /* InputTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputTextField.swift; sourceTree = "<group>"; };
+		3200438E2CDF3D7F00D08B6D /* KeywordButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordButton.swift; sourceTree = "<group>"; };
+		3200438F2CDF3D7F00D08B6D /* KeywordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordView.swift; sourceTree = "<group>"; };
+		320043902CDF3D7F00D08B6D /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
+		320043962CDF493600D08B6D /* Extension + UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIView.swift"; sourceTree = "<group>"; };
 		FD3A03202CD8CDE50047B7ED /* SniffMeet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SniffMeet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD3A03382CD8CF460047B7ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FD3A03392CD8CF460047B7ED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -44,13 +58,12 @@
 		A2C844CF2CDBE1CB007F2970 /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				320043752CDCA17E00D08B6D /* Extension + Navigation.swift */,
-				320043712CDC9E5F00D08B6D /* TestViewController.swift */,
-				3200437B2CDCA6F300D08B6D /* TestViewController.swift */,
-				3200436F2CDC99F900D08B6D /* InputTextField.swift */,
-				A2C844D02CDBE1E5007F2970 /* PrimaryButton.swift */,
-				320043772CDCA48900D08B6D /* KeywordView.swift */,
-				A2C844D62CDBEF8B007F2970 /* KeywordButton.swift */,
+				320043962CDF493600D08B6D /* Extension + UIView.swift */,
+				3200438C2CDF3D7F00D08B6D /* Extension + Navigation.swift */,
+				3200438D2CDF3D7F00D08B6D /* InputTextField.swift */,
+				3200438E2CDF3D7F00D08B6D /* KeywordButton.swift */,
+				3200438F2CDF3D7F00D08B6D /* KeywordView.swift */,
+				320043902CDF3D7F00D08B6D /* PrimaryButton.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -74,7 +87,6 @@
 		FD3A033E2CD8CF460047B7ED /* SniffMeet */ = {
 			isa = PBXGroup;
 			children = (
-				A288A63C2CDC595000D11C34 /* .swiftlint.yml */,
 				FDA491332CD9FE7C00A36FB0 /* Source */,
 				FDA4912A2CD9FE3500A36FB0 /* Resource */,
 			);
@@ -517,6 +529,7 @@
 		FDA491682CDA7C0300A36FB0 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				3200438A2CDF3BE900D08B6D /* ProfileSetupView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -878,7 +891,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A288A63D2CDC595000D11C34 /* .swiftlint.yml in Resources */,
+				A288A63D2CDC595000D11C34 /* (null) in Resources */,
 				FD3A033F2CD8CF460047B7ED /* Assets.xcassets in Resources */,
 				FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */,
 			);
@@ -891,15 +904,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A2C844D12CDBE1E5007F2970 /* PrimaryButton.swift in Sources */,
+				A2C844D12CDBE1E5007F2970 /* (null) in Sources */,
 				FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */,
 				FD3A03432CD8CF460047B7ED /* SceneDelegate.swift in Sources */,
-				320043762CDCA18E00D08B6D /* Extension + Navigation.swift in Sources */,
-				320043782CDCA49100D08B6D /* KeywordView.swift in Sources */,
-				A2C844D72CDBEF8B007F2970 /* KeywordButton.swift in Sources */,
-				320043722CDC9E5F00D08B6D /* TestViewController.swift in Sources */,
-				3200437C2CDCA6F300D08B6D /* TestViewController.swift in Sources */,
-				320043702CDC9A0D00D08B6D /* InputTextField.swift in Sources */,
+				320043762CDCA18E00D08B6D /* (null) in Sources */,
+				320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */,
+				320043782CDCA49100D08B6D /* (null) in Sources */,
+				320043912CDF3D7F00D08B6D /* KeywordButton.swift in Sources */,
+				320043922CDF3D7F00D08B6D /* InputTextField.swift in Sources */,
+				320043932CDF3D7F00D08B6D /* KeywordView.swift in Sources */,
+				320043942CDF3D7F00D08B6D /* PrimaryButton.swift in Sources */,
+				320043952CDF3D7F00D08B6D /* Extension + Navigation.swift in Sources */,
+				A2C844D72CDBEF8B007F2970 /* (null) in Sources */,
+				3200438B2CDF3BEF00D08B6D /* ProfileSetupView.swift in Sources */,
+				320043722CDC9E5F00D08B6D /* (null) in Sources */,
+				3200437C2CDCA6F300D08B6D /* (null) in Sources */,
+				320043702CDC9A0D00D08B6D /* (null) in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileSetupView.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileSetupView.swift
@@ -1,0 +1,109 @@
+//
+//  ProfileSetupView.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 11/9/24.
+//
+
+import UIKit
+
+final class ProfileSetupView: UIViewController {
+    private var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = Context.mainTitle
+        label.textColor = UIColor.mainNavy
+        label.numberOfLines = 2
+        label.font = UIFont.systemFont(ofSize: 24, weight: .heavy)
+        return label
+    }()
+    private var profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "ImagePlaceholder")
+        return imageView
+    }()
+    private var addPhotoButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "photo"), for: .normal)
+        button.backgroundColor = UIColor.mainNavy
+        button.setTitleColor(UIColor.white, for: .normal)
+        button.tintColor = UIColor.white
+        return button
+    }()
+    private var warningLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = UIColor.red
+        label.text = "이미 존재하는 닉네임입니다."
+        label.font = UIFont.systemFont(ofSize: 12)
+        return label
+    }()
+    private var nicknameTextField: InputTextField = InputTextField(placeholder: Context.placeholder)
+    private var submitButton = PrimaryButton(title: Context.submitBtnTitle)
+    
+    override func viewDidLoad() {
+        setSubviewsLayout()
+        view.backgroundColor = .white
+    }
+    override func viewDidLayoutSubviews() {
+        profileImageView.makeViewCircular()
+        addPhotoButton.makeViewCircular()
+    }
+}
+
+private extension ProfileSetupView {
+    enum Context {
+        static let submitBtnTitle: String = "등록 완료"
+        static let placeholder: String = "닉네임을 입력해주세요."
+        static let mainTitle: String = "마지막으로,\n사진과 닉네임을 등록해주세요."
+        static let horizontalPadding: CGFloat = 24
+        static let imageViewSize: CGFloat = 140
+        static let addPhotoButtonSize: CGFloat = 44
+    }
+    enum TextFieldError: Error {
+        case none               // 에러가 없는 경우
+        case empty              // 아무것도 입력되지 않은 경우
+        case exceededMaxLength  // 최대 글자 수를 초과한 경우
+        case invalidFormat      // 포맷이 잘못된 경우 (예: 이메일 형식 등)
+        case restrictedCharacter // 허용되지 않은 문자 포함
+    }
+    func setSubviewsLayout() {
+        [titleLabel,
+         profileImageView,
+         addPhotoButton,
+         warningLabel,
+         nicknameTextField,
+         submitButton].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor,
+                                                constant: Context.horizontalPadding),
+            profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            profileImageView.widthAnchor.constraint(equalToConstant: Context.imageViewSize),
+            profileImageView.heightAnchor.constraint(equalToConstant: Context.imageViewSize),
+            profileImageView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 80),
+            addPhotoButton.widthAnchor.constraint(equalToConstant: Context.addPhotoButtonSize),
+            addPhotoButton.heightAnchor.constraint(equalToConstant: Context.addPhotoButtonSize),
+            addPhotoButton.trailingAnchor.constraint(equalTo: profileImageView.trailingAnchor,
+                                                     constant: 10),
+            addPhotoButton.bottomAnchor.constraint(equalTo: profileImageView.bottomAnchor),
+            nicknameTextField.topAnchor.constraint(equalTo: profileImageView.bottomAnchor,
+                                                   constant: 60),
+            nicknameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor,
+                                                       constant: Context.horizontalPadding),
+            nicknameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor,
+                                                        constant: -Context.horizontalPadding),
+            warningLabel.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor,
+                                              constant: 16),
+            warningLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor,
+                                                  constant: Context.horizontalPadding),
+            submitButton.leadingAnchor.constraint(equalTo: view.leadingAnchor,
+                                                  constant: Context.horizontalPadding),
+            submitButton.trailingAnchor.constraint(equalTo: view.trailingAnchor,
+                                                   constant: -Context.horizontalPadding),
+            submitButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -32)
+        ])
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileSetupView.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileSetupView.swift
@@ -137,7 +137,7 @@ extension ProfileSetupView: PHPickerViewControllerDelegate {
            itemProvider.canLoadObject(ofClass: UIImage.self) {
             itemProvider.loadObject(ofClass: UIImage.self) { image, error in
                 guard let selectedImage = image as? UIImage else { return }
-                DispatchQueue.main.async { [weak self] in
+                Task { @MainActor [weak self] in
                     self?.profileImageView.image =  selectedImage
                 }
             }
@@ -147,10 +147,6 @@ extension ProfileSetupView: PHPickerViewControllerDelegate {
 
 extension ProfileSetupView: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        if (textField.text?.count ?? 0 < 1) || (textField.text?.count ?? 0 < 1) {
-            submitButton.isEnabled = false
-        } else {
-            submitButton.isEnabled = true
-        }
+        submitButton.isEnabled = (textField.text?.count ?? 0 > 1)
     }
 }

--- a/SniffMeet/SniffMeet/Source/Common/Extension + UIView.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Extension + UIView.swift
@@ -1,0 +1,17 @@
+//
+//  Extension + UIView.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 11/9/24.
+//
+
+import UIKit
+
+extension UIView {
+    func makeViewCircular() {
+        layer.cornerRadius = frame.size.width / 2
+        
+        print("frame: \(frame.size.width)")
+        clipsToBounds = true
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Common/Extension + UIView.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Extension + UIView.swift
@@ -10,8 +10,6 @@ import UIKit
 extension UIView {
     func makeViewCircular() {
         layer.cornerRadius = frame.size.width / 2
-        
-        print("frame: \(frame.size.width)")
         clipsToBounds = true
     }
 }

--- a/SniffMeet/SniffMeet/Source/Common/PrimaryButton.swift
+++ b/SniffMeet/SniffMeet/Source/Common/PrimaryButton.swift
@@ -36,7 +36,19 @@ final class PrimaryButton: UIButton {
                 [.font: UIFont.systemFont(ofSize: 16.0, weight: .bold)]
             )
         )
+        
+        let handler: UIButton.ConfigurationUpdateHandler = { button in
+            switch button.state {
+            case .disabled:
+                button.configuration?.baseBackgroundColor = .systemGray3
+            case .normal:
+                button.configuration?.baseBackgroundColor = .mainNavy
+            default:
+                break
+            }
+        }
 
         self.configuration = configuration
+        self.configurationUpdateHandler = handler
     }
 }


### PR DESCRIPTION
### 🔖 Issue Number

https://github.com/boostcampwm-2024/iOS03-SniffMeet/issues/24#issue-2645682339


### 📙 작업 내역

1. 피그마에 맞게 프로필 및 이미지 생성 뷰 UI를 만들었습니다. 

| 경고 라벨 활성화 ver |  경고 라벨 비활성화 ver |
| --- | --- |
|<img width="240" alt="스크린샷 2024-11-07 오후 3 18 08" src="https://github.com/user-attachments/assets/41a0b886-f127-497a-ba6b-ddeee468e80e">  | <img width="240" alt="스크린샷 2024-11-07 오후 3 18 08" src="https://github.com/user-attachments/assets/a8d090ac-d80c-4287-b210-0a2afffb2ac7"> |

2. PHPickerViewcontroller를 이용하여 갤러리에서 이미지를 가져올 수 있도록 구현했습니다. 

```swift 
 func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
      ...
         itemProvider.loadObject(ofClass: UIImage.self) { image, error in
             guard let selectedImage = image as? UIImage else { return }
             DispatchQueue.main.async { [weak self] in
                 self?.profileImageView.image =  selectedImage
             }
         }
    }
```
main thread가 아닌 다른 thread에서 해당 코드가 실행될 위험이 있어서 
imageview의 image를 바꿀 때 mainThread에서 변경할 수 있도록 이렇게 코드를 작성했는데요. 제가 맞게 판단한건지 팀원분들의 의견이 궁금합니다. 

3. TextField 텍스트의 유무에 따른 버튼 활성화 

2, 3번 실행 화면 
Simulator Screen Recording - iPhone 16 - 2024-11-09 at 23.58.13.mp4

4. Common 폴더의 PrimaryButton에 버튼의 상태에 따라 backgroundColor 설정 
- 해당 버튼에 버튼 상태에 따라 배경색을 설정하는 코드가 빠져있어 추가로 작성했습니다. 

### 📝 PR 특이사항 
- Viper 패턴에 따르면 Viewcontroller 파일이 View 폴더에 속합니다. 따라서 view controller 파일을 생성할 때 ~view라고 명명하면 어떨지 제안드리고 싶습니다! 
- 프로필 및 닉네임 설정 화면이어서 이름을 ProfileSetupView라고 지었는데요. 이름이 어색하지 않은지 궁금합니다... 의견 주시면 수정해볼게요!
