### PR TITLE
[design] 폰트 및 색상 네임스페이스 구현 레이아웃 상수 추가

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		FD3A03432CD8CF460047B7ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */; };
 		FDBFA99F2CE1E50C00AA9220 /* SNMFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBFA99E2CE1E50900AA9220 /* SNMFont.swift */; };
 		FDBFA9A12CE1E51500AA9220 /* SNMColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBFA9A02CE1E51000AA9220 /* SNMColor.swift */; };
+		FDBFA9B12CE1FE5500AA9220 /* LayoutConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBFA9B02CE1FDED00AA9220 /* LayoutConstant.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +47,7 @@
 		FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		FDBFA99E2CE1E50900AA9220 /* SNMFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMFont.swift; sourceTree = "<group>"; };
 		FDBFA9A02CE1E51000AA9220 /* SNMColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMColor.swift; sourceTree = "<group>"; };
+		FDBFA9B02CE1FDED00AA9220 /* LayoutConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConstant.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +64,7 @@
 		A2C844CF2CDBE1CB007F2970 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				FDBFA9B02CE1FDED00AA9220 /* LayoutConstant.swift */,
 				FDBFA9A02CE1E51000AA9220 /* SNMColor.swift */,
 				FDBFA99E2CE1E50900AA9220 /* SNMFont.swift */,
 				320043962CDF493600D08B6D /* Extension + UIView.swift */,
@@ -917,6 +920,7 @@
 				320043762CDCA18E00D08B6D /* (null) in Sources */,
 				320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */,
 				320043782CDCA49100D08B6D /* (null) in Sources */,
+				FDBFA9B12CE1FE5500AA9220 /* LayoutConstant.swift in Sources */,
 				320043912CDF3D7F00D08B6D /* KeywordButton.swift in Sources */,
 				320043922CDF3D7F00D08B6D /* InputTextField.swift in Sources */,
 				320043932CDF3D7F00D08B6D /* KeywordView.swift in Sources */,

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */; };
 		FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A03382CD8CF460047B7ED /* AppDelegate.swift */; };
 		FD3A03432CD8CF460047B7ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */; };
+		FDBFA99F2CE1E50C00AA9220 /* SNMFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBFA99E2CE1E50900AA9220 /* SNMFont.swift */; };
+		FDBFA9A12CE1E51500AA9220 /* SNMColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBFA9A02CE1E51000AA9220 /* SNMColor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +44,8 @@
 		FD3A033A2CD8CF460047B7ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FD3A033B2CD8CF460047B7ED /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		FDBFA99E2CE1E50900AA9220 /* SNMFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMFont.swift; sourceTree = "<group>"; };
+		FDBFA9A02CE1E51000AA9220 /* SNMColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMColor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,6 +62,8 @@
 		A2C844CF2CDBE1CB007F2970 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				FDBFA9A02CE1E51000AA9220 /* SNMColor.swift */,
+				FDBFA99E2CE1E50900AA9220 /* SNMFont.swift */,
 				320043962CDF493600D08B6D /* Extension + UIView.swift */,
 				3200438C2CDF3D7F00D08B6D /* Extension + Navigation.swift */,
 				3200438D2CDF3D7F00D08B6D /* InputTextField.swift */,
@@ -904,6 +910,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FDBFA9A12CE1E51500AA9220 /* SNMColor.swift in Sources */,
 				A2C844D12CDBE1E5007F2970 /* (null) in Sources */,
 				FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */,
 				FD3A03432CD8CF460047B7ED /* SceneDelegate.swift in Sources */,
@@ -915,6 +922,7 @@
 				320043932CDF3D7F00D08B6D /* KeywordView.swift in Sources */,
 				320043942CDF3D7F00D08B6D /* PrimaryButton.swift in Sources */,
 				320043952CDF3D7F00D08B6D /* Extension + Navigation.swift in Sources */,
+				FDBFA99F2CE1E50C00AA9220 /* SNMFont.swift in Sources */,
 				A2C844D72CDBEF8B007F2970 /* (null) in Sources */,
 				3200438B2CDF3BEF00D08B6D /* ProfileSetupView.swift in Sources */,
 				320043722CDC9E5F00D08B6D /* (null) in Sources */,

--- a/SniffMeet/SniffMeet/Source/Common/LayoutConstant.swift
+++ b/SniffMeet/SniffMeet/Source/Common/LayoutConstant.swift
@@ -1,0 +1,23 @@
+//
+//  LayoutConstant.swift
+//  SniffMeet
+//
+//  Created by sole on 11/11/24.
+//
+
+import CoreGraphics
+
+enum LayoutConstant {
+    static let iconSize: CGFloat = 24
+
+    static let horizontalPadding: CGFloat = 24
+
+    static let smallVerticalPadding: CGFloat = 8
+    static let regularVerticalPadding: CGFloat = 16
+    static let mediumVerticalPadding: CGFloat = 24
+    static let largeVerticalPadding: CGFloat = 30
+    static let xlargeVerticalPadding: CGFloat = 32
+
+    static let tagHorizontalSpacing: CGFloat = 8
+    static let navigationItemSpacing: CGFloat = 4
+}

--- a/SniffMeet/SniffMeet/Source/Common/SNMColor.swift
+++ b/SniffMeet/SniffMeet/Source/Common/SNMColor.swift
@@ -1,0 +1,34 @@
+//
+//  SNMColor.swift
+//  SniffMeet
+//
+//  Created by sole on 11/11/24.
+//
+
+import UIKit
+
+enum SNMColor {
+    static let mainNavy: UIColor = UIColor.mainNavy
+    static let mainWhite: UIColor = UIColor.mainWhite
+    static let mainBrown: UIColor = UIColor.brown
+    static let subGray1: UIColor = UIColor.subGray1
+    static let subGray2: UIColor = UIColor(hex: 0xC0C0C0)
+    static let text1: UIColor = UIColor(hex: 0xCCD7DC)
+    static let disabledGray: UIColor = UIColor(hex: 0xE6EAEC)
+    static let warningRed: UIColor = UIColor(hex: 0xF64545)
+    static let cardIconButtonBackground: UIColor = UIColor(hex: 0xECECEC, alpha: 0.87)
+}
+
+// MARK: - UIColor+init
+
+extension UIColor {
+    /// hex 값은 0x000000 (0x 뒤 여섯자리(0-F) 값)과 같은 형식만 넣어야합니다. 예시: 0xC0C0C, 0xECECEC, 0xF64545
+    convenience init(hex: UInt, alpha: CGFloat = 1) {
+        self.init(
+            red: Double((hex >> 16) & 0xff) / 255,
+            green: Double((hex >> 8) & 0xff) / 255,
+            blue: Double((hex >> 0) & 0xff) / 255,
+            alpha: alpha
+        )
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Common/SNMFont.swift
+++ b/SniffMeet/SniffMeet/Source/Common/SNMFont.swift
@@ -1,0 +1,29 @@
+//
+//  SNMFont.swift
+//  SniffMeet
+//
+//  Created by sole on 11/11/24.
+//
+
+import UIKit
+
+enum SNMFont {
+    /// size: 34, weight: bold
+    static let largeTitle: UIFont = UIFont.systemFont(ofSize: 34, weight: .bold)
+    /// size: 32,weight: bold
+    static let title1: UIFont = UIFont.systemFont(ofSize: 32, weight: .bold)
+    /// size: 24, weight: heavy
+    static let title2: UIFont = UIFont.systemFont(ofSize: 24, weight: .heavy)
+    /// size: 24,weight: semibold
+    static let title3: UIFont = UIFont.systemFont(ofSize: 24, weight: .semibold)
+    /// size: 16, weight: regular
+    static let body: UIFont = UIFont.systemFont(ofSize: 16, weight: .regular)
+    /// size: 17, weight: semibold
+    static let headline: UIFont = UIFont.systemFont(ofSize: 17, weight: .semibold)
+    /// size: 14, weight: regular
+    static let subheadline: UIFont = UIFont.systemFont(ofSize: 14, weight: .regular)
+    /// size: 16, weight: semibold
+    static let callout: UIFont = UIFont.systemFont(ofSize: 16, weight: .semibold)
+    /// size: 12, weight: regular
+    static let caption: UIFont = UIFont.systemFont(ofSize: 12, weight: .regular)
+}


### PR DESCRIPTION
### 🔖  Issue Number

close #33 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- UIColor+init 익스텐션 구현 

Color가 추가될 때마다 익스텐션으로 관리하기 까다로울 것 같아서 hex 값 생성자를 구현했습니다. 추가된 색상도 hex값을 통해 생성했습니다. 

``` swift 
convenience init(hex: UInt, alpha: CGFloat = 1) {
        self.init(
            red: Double((hex >> 16) & 0xff) / 255,
            green: Double((hex >> 8) & 0xff) / 255,
            blue: Double((hex >> 0) & 0xff) / 255,
            alpha: alpha
        )
    }
```
-  SNMColor 구현 
Color 이름하고 같이 띄우고 싶었는데, 잘 안되네요... 

<img src="https://github.com/user-attachments/assets/301563ac-a068-420e-8f41-7fc4250ca3a6" height=300>

- SNMFont 구현 

<img src="https://github.com/user-attachments/assets/8b5315fc-5029-4169-aabf-001dae3f3d3a" height=300>

- LayoutConstant 추가 

프로젝트 UI 구현에 자주 사용되는 레이아웃 상수 값을 정의했습니다. 

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 일단 피그마에서 찾은만큼 추가해두긴 했는데 누락되거나 추후 추가될 Color, Font는 SNMFont, Color에 추가해 사용하면 될것 같습니다~
