### PR TITLE
[feat] 비활성화 배경색 지정 및 키보드 extension 분리

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -12,9 +12,6 @@
 		320043762CDCA18E00D08B6D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		320043782CDCA49100D08B6D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		3200437C2CDCA6F300D08B6D /* (null) in Sources */ = {isa = PBXBuildFile; };
-		99FA4E792CE0FBBF00553C2E /* ProfileInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA4E782CE0FBBF00553C2E /* ProfileInputView.swift */; };
-		A2F825D12CDF4BA6000C5419 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F825D02CDF4BA6000C5419 /* HomeViewController.swift */; };
-		A2F825DD2CDFBEB4000C5419 /* ProfileCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F825DC2CDFBEB4000C5419 /* ProfileCardView.swift */; };
 		3200438B2CDF3BEF00D08B6D /* ProfileSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438A2CDF3BE900D08B6D /* ProfileSetupView.swift */; };
 		320043912CDF3D7F00D08B6D /* KeywordButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438E2CDF3D7F00D08B6D /* KeywordButton.swift */; };
 		320043922CDF3D7F00D08B6D /* InputTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438D2CDF3D7F00D08B6D /* InputTextField.swift */; };
@@ -22,9 +19,13 @@
 		320043942CDF3D7F00D08B6D /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043902CDF3D7F00D08B6D /* PrimaryButton.swift */; };
 		320043952CDF3D7F00D08B6D /* Extension + Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438C2CDF3D7F00D08B6D /* Extension + Navigation.swift */; };
 		320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043962CDF493600D08B6D /* Extension + UIView.swift */; };
+		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
+		99FA4E792CE0FBBF00553C2E /* ProfileInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA4E782CE0FBBF00553C2E /* ProfileInputView.swift */; };
 		A288A63D2CDC595000D11C34 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		A2C844D12CDBE1E5007F2970 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		A2C844D72CDBEF8B007F2970 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		A2F825D12CDF4BA6000C5419 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F825D02CDF4BA6000C5419 /* HomeViewController.swift */; };
+		A2F825DD2CDFBEB4000C5419 /* ProfileCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F825DC2CDFBEB4000C5419 /* ProfileCardView.swift */; };
 		FD3A033F2CD8CF460047B7ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FD3A03392CD8CF460047B7ED /* Assets.xcassets */; };
 		FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */; };
 		FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A03382CD8CF460047B7ED /* AppDelegate.swift */; };
@@ -35,9 +36,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		99FA4E782CE0FBBF00553C2E /* ProfileInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputView.swift; sourceTree = "<group>"; };
-		A2F825D02CDF4BA6000C5419 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
-		A2F825DC2CDFBEB4000C5419 /* ProfileCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCardView.swift; sourceTree = "<group>"; };
 		3200438A2CDF3BE900D08B6D /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
 		3200438C2CDF3D7F00D08B6D /* Extension + Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Navigation.swift"; sourceTree = "<group>"; };
 		3200438D2CDF3D7F00D08B6D /* InputTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputTextField.swift; sourceTree = "<group>"; };
@@ -45,6 +43,10 @@
 		3200438F2CDF3D7F00D08B6D /* KeywordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordView.swift; sourceTree = "<group>"; };
 		320043902CDF3D7F00D08B6D /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
 		320043962CDF493600D08B6D /* Extension + UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIView.swift"; sourceTree = "<group>"; };
+		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
+		99FA4E782CE0FBBF00553C2E /* ProfileInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputView.swift; sourceTree = "<group>"; };
+		A2F825D02CDF4BA6000C5419 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		A2F825DC2CDFBEB4000C5419 /* ProfileCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCardView.swift; sourceTree = "<group>"; };
 		FD3A03202CD8CDE50047B7ED /* SniffMeet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SniffMeet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD3A03382CD8CF460047B7ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FD3A03392CD8CF460047B7ED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -73,6 +75,7 @@
 				FDBFA9B02CE1FDED00AA9220 /* LayoutConstant.swift */,
 				FDBFA9A02CE1E51000AA9220 /* SNMColor.swift */,
 				FDBFA99E2CE1E50900AA9220 /* SNMFont.swift */,
+				995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */,
 				320043962CDF493600D08B6D /* Extension + UIView.swift */,
 				3200438C2CDF3D7F00D08B6D /* Extension + Navigation.swift */,
 				3200438D2CDF3D7F00D08B6D /* InputTextField.swift */,
@@ -929,6 +932,7 @@
 				99FA4E792CE0FBBF00553C2E /* ProfileInputView.swift in Sources */,
 				320043762CDCA18E00D08B6D /* (null) in Sources */,
 				A2F825DD2CDFBEB4000C5419 /* ProfileCardView.swift in Sources */,
+				995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */,
 				A2F825D12CDF4BA6000C5419 /* HomeViewController.swift in Sources */,
 				320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */,
 				320043782CDCA49100D08B6D /* (null) in Sources */,

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileInputView.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileInputView.swift
@@ -46,7 +46,6 @@ final class ProfileInputView: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = SNMColor.white
-
         setSubveiws()
         setSubviewsLayout()
         updateNextButtonState()
@@ -167,19 +166,6 @@ private extension ProfileInputView {
                                                 constant: Context.horizontalPadding),
             nextButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Context.horizontalPadding)
         ])
-    }
-}
-
-extension ProfileInputView {
-    func hideKeyboardWhenTappedAround() {
-        let tap = UITapGestureRecognizer(target: self,
-                                         action: #selector(ProfileInputView.dismissKeyboard))
-        tap.cancelsTouchesInView = false
-        view.addGestureRecognizer(tap)
-    }
-
-    @objc func dismissKeyboard() {
-        view.endEditing(true)
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileInputView.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileInputView.swift
@@ -11,7 +11,7 @@ final class ProfileInputView: UIViewController {
     private var titleLabel: UILabel = {
         let label = UILabel()
         label.text = Context.titleLabel
-        label.textColor = UIColor.mainNavy
+        label.textColor = SNMColor.mainNavy
         label.numberOfLines = 2
         label.font = .systemFont(ofSize: .init(24), weight: .heavy)
         return label
@@ -45,7 +45,7 @@ final class ProfileInputView: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .white
+        view.backgroundColor = SNMColor.white
 
         setSubveiws()
         setSubviewsLayout()

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileSetupView.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileSetupView.swift
@@ -53,6 +53,7 @@ final class ProfileSetupView: UIViewController {
         submitButton.isEnabled = false
         setDelegate()
         setButtonAction()
+        hideKeyboardWhenTappedAround()
     }
     override func viewDidLayoutSubviews() {
         profileImageView.makeViewCircular()

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileSetupView.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileSetupView.swift
@@ -12,7 +12,7 @@ final class ProfileSetupView: UIViewController {
     private var titleLabel: UILabel = {
         let label = UILabel()
         label.text = Context.mainTitle
-        label.textColor = UIColor.mainNavy
+        label.textColor = SNMColor.mainNavy
         label.numberOfLines = 2
         label.font = UIFont.systemFont(ofSize: 24, weight: .heavy)
         return label
@@ -25,14 +25,14 @@ final class ProfileSetupView: UIViewController {
     private var addPhotoButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "photo"), for: .normal)
-        button.backgroundColor = UIColor.mainNavy
-        button.setTitleColor(UIColor.white, for: .normal)
-        button.tintColor = UIColor.white
+        button.backgroundColor = SNMColor.mainNavy
+        button.setTitleColor(SNMColor.white, for: .normal)
+        button.tintColor = SNMColor.white
         return button
     }()
     private var warningLabel: UILabel = {
         let label = UILabel()
-        label.textColor = UIColor.red
+        label.textColor = SNMColor.warningRed
         label.text = Context.placeholder
         label.alpha = 0
         label.font = UIFont.systemFont(ofSize: 12)
@@ -49,7 +49,7 @@ final class ProfileSetupView: UIViewController {
 
     override func viewDidLoad() {
         setSubviewsLayout()
-        view.backgroundColor = .white
+        view.backgroundColor = SNMColor.white
         submitButton.isEnabled = false
         setDelegate()
         setButtonAction()

--- a/SniffMeet/SniffMeet/Source/Common/Extension + Keyboard.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Extension + Keyboard.swift
@@ -1,0 +1,21 @@
+//
+//  Extension + Keyboard.swift
+//  SniffMeet
+//
+//  Created by 배현진 on 11/12/24.
+//
+
+import UIKit
+
+extension UIViewController {
+    func hideKeyboardWhenTappedAround() {
+        let tap = UITapGestureRecognizer(target: self,
+                                         action: #selector(ProfileInputView.dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Common/Extension + Navigation.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Extension + Navigation.swift
@@ -20,4 +20,3 @@ extension UINavigationItem {
         scrollEdgeAppearance = appearance
     }
 }
-

--- a/SniffMeet/SniffMeet/Source/Common/InputTextField.swift
+++ b/SniffMeet/SniffMeet/Source/Common/InputTextField.swift
@@ -21,7 +21,7 @@ final class InputTextField: UITextField {
         super.init(coder: coder)
     }
     private func setupConfiguration(placeholder: String) {
-        backgroundColor = .subGray1
+        backgroundColor = SNMColor.subGray1
         self.placeholder = placeholder
         borderStyle = .none
         layer.cornerRadius = Context.cornerRadius

--- a/SniffMeet/SniffMeet/Source/Common/KeywordButton.swift
+++ b/SniffMeet/SniffMeet/Source/Common/KeywordButton.swift
@@ -24,15 +24,16 @@ final class KeywordButton: UIButton {
         let handler: UIButton.ConfigurationUpdateHandler = { button in
             switch button.state {
             case .selected:
-                button.configuration?.baseBackgroundColor = .mainBrown
+                button.configuration?.baseBackgroundColor = SNMColor.mainBrown
             case .normal:
-                button.configuration?.baseBackgroundColor = .systemGray3
+                button.configuration?.baseBackgroundColor = SNMColor.disabledGray
             default:
                 break
             }
         }
         configuration.title = title
-        configuration.baseForegroundColor = .white
+        configuration.baseForegroundColor = SNMColor.white
+        configuration.baseForegroundColor = SNMColor.black
         configuration.cornerStyle = .capsule
         configuration.contentInsets = NSDirectionalEdgeInsets(
             top: 6,

--- a/SniffMeet/SniffMeet/Source/Common/KeywordView.swift
+++ b/SniffMeet/SniffMeet/Source/Common/KeywordView.swift
@@ -41,7 +41,7 @@ final class KeywordView: UILabel {
         font = UIFont.systemFont(ofSize: 14)
         layer.cornerRadius = Context.cornerRadius
         layer.masksToBounds = true
-        self.backgroundColor = UIColor.white
+        self.backgroundColor = SNMColor.white
 
     }
 }

--- a/SniffMeet/SniffMeet/Source/Common/PrimaryButton.swift
+++ b/SniffMeet/SniffMeet/Source/Common/PrimaryButton.swift
@@ -40,9 +40,9 @@ final class PrimaryButton: UIButton {
         let handler: UIButton.ConfigurationUpdateHandler = { button in
             switch button.state {
             case .disabled:
-                button.configuration?.baseBackgroundColor = .systemGray3
+                button.configuration?.background.backgroundColor = SNMColor.disabledGray
             case .normal:
-                button.configuration?.baseBackgroundColor = .mainNavy
+                button.configuration?.background.backgroundColor = SNMColor.mainNavy
             default:
                 break
             }

--- a/SniffMeet/SniffMeet/Source/Common/PrimaryButton.swift
+++ b/SniffMeet/SniffMeet/Source/Common/PrimaryButton.swift
@@ -21,8 +21,8 @@ final class PrimaryButton: UIButton {
     private func setupConfiguration(title: String) {
         var configuration = UIButton.Configuration.filled()
         configuration.title = title
-        configuration.baseBackgroundColor = .mainNavy
-        configuration.baseForegroundColor = .white
+        configuration.baseBackgroundColor = SNMColor.mainNavy
+        configuration.baseForegroundColor = SNMColor.white
         configuration.cornerStyle = .large
         configuration.contentInsets = NSDirectionalEdgeInsets(
             top: 20,

--- a/SniffMeet/SniffMeet/Source/Common/SNMColor.swift
+++ b/SniffMeet/SniffMeet/Source/Common/SNMColor.swift
@@ -10,7 +10,8 @@ import UIKit
 enum SNMColor {
     static let mainNavy: UIColor = UIColor.mainNavy
     static let mainWhite: UIColor = UIColor.mainWhite
-    static let mainBrown: UIColor = UIColor.brown
+    static let mainBrown: UIColor = UIColor.mainBrown
+    static let mainBeige: UIColor = UIColor.mainBeige
     static let subGray1: UIColor = UIColor.subGray1
     static let subGray2: UIColor = UIColor(hex: 0xC0C0C0)
     static let text1: UIColor = UIColor(hex: 0xCCD7DC)

--- a/SniffMeet/SniffMeet/Source/Common/SNMColor.swift
+++ b/SniffMeet/SniffMeet/Source/Common/SNMColor.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 enum SNMColor {
+    static let black: UIColor = UIColor.black
+    static let white: UIColor = UIColor.white
     static let mainNavy: UIColor = UIColor.mainNavy
     static let mainWhite: UIColor = UIColor.mainWhite
     static let mainBrown: UIColor = UIColor.mainBrown

--- a/SniffMeet/SniffMeet/Source/Home/Main/View/ProfileCardView.swift
+++ b/SniffMeet/SniffMeet/Source/Home/Main/View/ProfileCardView.swift
@@ -25,12 +25,7 @@ final class ProfileCardView: UIView {
         let button = UIButton(frame: CGRect(x: 0, y: 0, width: 44, height: 44))
         button.setImage(UIImage(systemName: "pencil"), for: .normal)
         button.tintColor = .label
-        button.backgroundColor = UIColor(
-            red: 236 / 255,
-            green: 236 / 255,
-            blue: 236 / 255,
-            alpha: 0.87
-        )
+        button.backgroundColor = SNMColor.cardIconButtonBackground
         button.layer.cornerRadius = 22
         return button
     }()
@@ -102,14 +97,14 @@ final class ProfileCardView: UIView {
     private func setShadow() {
         layer.cornerRadius = 15
         layer.shadowOffset = CGSize(width: 0, height: 4)
-        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowColor = SNMColor.black.cgColor
         layer.shadowOpacity = 0.25
         layer.shadowRadius = 4
         layer.masksToBounds = false
     }
     private func setNameLabelShadow() {
         nameLabel.layer.shadowOffset = CGSize(width: 0, height: 4)
-        nameLabel.layer.shadowColor = UIColor.black.cgColor
+        nameLabel.layer.shadowColor = SNMColor.black.cgColor
         nameLabel.layer.shadowOpacity = 0.25
         nameLabel.layer.shadowRadius = 3.0
         nameLabel.layer.masksToBounds = false


### PR DESCRIPTION
### 🔖  Issue Number

close https://github.com/boostcampwm-2024/iOS03-SniffMeet/issues/39

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  버튼 비활성화 상태에 색상 변경 구현
- [x]  SNMColor 색상 수정
- [x]  전체 코드 SNMColor 사용 방식으로 통일
- [x]  키보드 내리기 기능 extension 분리
- [x]  현재 TextField 사용하는 뷰에 키보드 내리기 기능 추가

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항은 아니고, 코드 전체적으로 달랐던 Color 사용법 SNMColor 사용 방식으로 통일 시켰습니다.
- SNMColor에 mainWhite와 white 두가지가 존재하는데, white는 일반 화이트 색상이고 mainWhite는 저희 컬러시스템에 있던 크림화이트 색상입니다.
- 키워드 버튼도 비활성화 상태?(선택되지 않은)일경우 disabledGray 컬러 적용시켰습니다. 그랬더니 흰색으로 설정된 텍스트들이 눈에 띄지 않아서 텍스트를 검정색으로 변경하였습니다. 키워드 선택되지 않았을경우도 비활성화 버튼으로 보는것이 맞을까요?

| 비활성화 버튼 색상 적용 전 ver |  비활성화 버튼 색상 적용 후 ver |
| --- | --- |
|<img width="240" src="https://github.com/user-attachments/assets/e748f7f0-5a07-4891-8c34-78b29719017d">  | <img width="240" src="https://github.com/user-attachments/assets/32ebb2b4-6a12-4f85-8a2d-42e09d370cbf"> |

- SNMFont나 LayoutConstraint 등도 오늘 밤?쯤에 통일시켜두겠습니다.
- 키보드 내리기 기능을 추가하고 싶다면 원하는 UIViewController에 hideKeyboardWhenTappedAround() 추가하면 됩니다.

### 👻 레퍼런스
