### PR TITLE
[feat] 앱 라우터 생성 및 SceneDelegate에 적용

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -19,12 +19,13 @@
 		320043942CDF3D7F00D08B6D /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043902CDF3D7F00D08B6D /* PrimaryButton.swift */; };
 		320043952CDF3D7F00D08B6D /* Extension + Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438C2CDF3D7F00D08B6D /* Extension + Navigation.swift */; };
 		320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043962CDF493600D08B6D /* Extension + UIView.swift */; };
-		A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21435F62CE20D2500564A4D /* TabBarController.swift */; };
 		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
 		99FA4E792CE0FBBF00553C2E /* ProfileInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA4E782CE0FBBF00553C2E /* ProfileInputView.swift */; };
+		A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21435F62CE20D2500564A4D /* TabBarController.swift */; };
 		A288A63D2CDC595000D11C34 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		A2C328862CE245AC00D255AB /* TabBarModuleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328852CE245AC00D255AB /* TabBarModuleBuilder.swift */; };
 		A2C328882CE2481900D255AB /* HomeModuleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328872CE2481900D255AB /* HomeModuleBuilder.swift */; };
+		A2C328922CE3BEA000D255AB /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328912CE3BEA000D255AB /* AppRouter.swift */; };
 		A2C844D12CDBE1E5007F2970 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		A2C844D72CDBEF8B007F2970 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		A2F825D12CDF4BA6000C5419 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F825D02CDF4BA6000C5419 /* HomeViewController.swift */; };
@@ -48,11 +49,12 @@
 		3200438F2CDF3D7F00D08B6D /* KeywordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordView.swift; sourceTree = "<group>"; };
 		320043902CDF3D7F00D08B6D /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
 		320043962CDF493600D08B6D /* Extension + UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIView.swift"; sourceTree = "<group>"; };
+		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
+		99FA4E782CE0FBBF00553C2E /* ProfileInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputView.swift; sourceTree = "<group>"; };
 		A21435F62CE20D2500564A4D /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		A2C328852CE245AC00D255AB /* TabBarModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarModuleBuilder.swift; sourceTree = "<group>"; };
 		A2C328872CE2481900D255AB /* HomeModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModuleBuilder.swift; sourceTree = "<group>"; };
-		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
-		99FA4E782CE0FBBF00553C2E /* ProfileInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputView.swift; sourceTree = "<group>"; };
+		A2C328912CE3BEA000D255AB /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
 		A2F825D02CDF4BA6000C5419 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		A2F825DC2CDFBEB4000C5419 /* ProfileCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCardView.swift; sourceTree = "<group>"; };
 		FD3A03202CD8CDE50047B7ED /* SniffMeet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SniffMeet.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -213,6 +215,7 @@
 			children = (
 				FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */,
 				FD3A03382CD8CF460047B7ED /* AppDelegate.swift */,
+				A2C328912CE3BEA000D255AB /* AppRouter.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -991,6 +994,7 @@
 				A2C328862CE245AC00D255AB /* TabBarModuleBuilder.swift in Sources */,
 				320043722CDC9E5F00D08B6D /* (null) in Sources */,
 				3200437C2CDCA6F300D08B6D /* (null) in Sources */,
+				A2C328922CE3BEA000D255AB /* AppRouter.swift in Sources */,
 				320043702CDC9A0D00D08B6D /* (null) in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SniffMeet/SniffMeet/Source/App/AppRouter.swift
+++ b/SniffMeet/SniffMeet/Source/App/AppRouter.swift
@@ -1,0 +1,39 @@
+//
+//  AppRouter.swift
+//  SniffMeet
+//
+//  Created by Kelly Chui on 11/12/24.
+//
+
+import UIKit
+
+final class AppRouter {
+    private var window: UIWindow?
+
+    init(window: UIWindow?) {
+        self.window = window
+    }
+
+    // 첫 화면을 뭘 보여줄지는 회원 가입 여부에 따라 앱 플로우가 다르므로, UIWindow를 이용해야 합니다.
+    func displayInitialScreen(isLoggedIn: Bool) {
+        if isLoggedIn {
+            displayTabBar()
+        } else {
+            displayProfileSetupView()
+        }
+    }
+    private func displayTabBar() {
+        let submodules = (
+            home: HomeModuleBuilder.build(),
+            walk: UIViewController(),
+            mate: UIViewController()
+        )
+        window?.rootViewController = TabBarModuleBuilder.build(usingSubmodules: submodules)
+        window?.makeKeyAndVisible()
+    }
+    private func displayProfileSetupView() {
+        let profileViewController = ProfileInputView()
+        window?.rootViewController = profileViewController
+        window?.makeKeyAndVisible()
+    }
+}

--- a/SniffMeet/SniffMeet/Source/App/SceneDelegate.swift
+++ b/SniffMeet/SniffMeet/Source/App/SceneDelegate.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
+    var appRouter: AppRouter?
 
     func scene(
         _ scene: UIScene,
@@ -16,15 +17,12 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         options connectionOptions: UIScene.ConnectionOptions
     ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        window = UIWindow(windowScene: windowScene)
-        let submodules = (
-            home: HomeModuleBuilder.build(),
-            walk: UIViewController(),
-            mate: UIViewController()
-        )
+        let window = UIWindow(windowScene: windowScene)
+        let appRouter = AppRouter(window: window)
+        self.window = window
+        self.appRouter = appRouter
 
-        let tabBarController = TabBarModuleBuilder.build(usingSubmodules: submodules)
-        window?.rootViewController = tabBarController
-        window?.makeKeyAndVisible()
+        appRouter.displayInitialScreen(isLoggedIn: true)
+        window.makeKeyAndVisible()
     }
 }


### PR DESCRIPTION
### 🔖  Issue Number

close #

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  앱 라우터 생성

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 시작 모듈을 선택할 때 `UIWindow`를 사용하는 이유
    - 사용자가 등록 되어있을 때 앱을 실행 시킨 것과, 그렇지 않았을 때 앱을 실행 시킨 것은 앱 플로우가 다르기 때문입니다.
    - 그 외 앱 중간에 `UIWindow`가 변경될 일은 현재는 없습니다.
- 앱 플로우가 직접적으로 변해야 하는 경우를 제외하고는 `UIWindow`를 변경시키지 않는 것이 좋습니다.

### 👻 레퍼런스
- [UIWindow](https://developer.apple.com/documentation/uikit/uiwindow)
- [Viper 패턴 라우터 코드 분석](https://prickly-theater-8f3.notion.site/13cade8f37658012aa98e4fa46316dca?pvs=4)
