### PR TITLE
[feat] KeychainManager / UserDefaultsManager 구현

### DIFF
--- a/SniffMeet/SNMPersistenceTests/KeychainTests.swift
+++ b/SniffMeet/SNMPersistenceTests/KeychainTests.swift
@@ -1,0 +1,71 @@
+//
+//  KeychainTests.swift
+//  SniffMeet
+//
+//  Created by sole on 11/13/24.
+//
+
+import XCTest
+
+final class KeychainTests: XCTestCase {
+    private var keychainManager: KeychainManager!
+    private let testKey: String = "test"
+
+    override func setUp() {
+        keychainManager = KeychainManager.shared
+    }
+    override func tearDown() {
+        try? keychainManager.delete(forKey: testKey)
+    }
+
+    func test_delete에서_삭제할_값이_없으면_에러를_반환한다() {
+        // given
+        // when
+        // then
+        XCTAssertThrowsError(try keychainManager.delete(forKey: testKey)) { error in
+            XCTAssert(error is KeychainError)
+            XCTAssertEqual(error as! KeychainError, KeychainError.keyNotFound)
+        }
+    }
+    func test_delete에서_삭제할_값이_있으면_삭제한다() throws {
+        // given
+        try keychainManager.set(value: "123", forKey: testKey)
+        // when
+        // then
+        try keychainManager.delete(forKey: testKey)
+    }
+    func test_set에서_이미_값이_존재하면_값을_덮어씌운다() throws {
+        // given
+        try keychainManager.set(value: "123", forKey: testKey)
+        // when
+        try keychainManager.set(value: "234", forKey: testKey)
+        // then
+        let value = try keychainManager.get(forKey: testKey)
+        XCTAssertEqual("234", value)
+    }
+    func test_set에서_값이_존재하지_않으면_값을_새로_설정한다() throws {
+        // given
+        // when
+        try keychainManager.set(value: "123", forKey: testKey)
+        // then
+        let value = try keychainManager.get(forKey: testKey)
+        XCTAssertEqual("123", value)
+    }
+    func test_get에서_값이_존재하지_않으면_keyNotFound에러를_반환한다() {
+        // given
+        // when
+        // then
+        XCTAssertThrowsError(try keychainManager.get(forKey: testKey)) { error in
+            XCTAssert(error is KeychainError)
+            XCTAssertEqual(error as! KeychainError, KeychainError.keyNotFound)
+        }
+    }
+    func test_get에서_값이_존재하면_값을_반환한다() throws {
+        // given
+        // when
+        try keychainManager.set(value: "123", forKey: testKey)
+        // then
+        let value = try keychainManager.get(forKey: testKey)
+        XCTAssertEqual("123", value)
+    }
+}

--- a/SniffMeet/SNMPersistenceTests/UserDefaultsTests.swift
+++ b/SniffMeet/SNMPersistenceTests/UserDefaultsTests.swift
@@ -1,0 +1,107 @@
+//
+//  UserDefaultsTests.swift
+//  SNMPersistenceTests
+//
+//  Created by sole on 11/13/24.
+//
+
+import XCTest
+
+final class UserDefaultsTests: XCTestCase {
+    private var userDefaultsManager: UserDefaultsManager!
+    private let userDefaults: UserDefaults = UserDefaults(suiteName: "SNMPersistenceTests.UserDefaultsManager")!
+
+    override func setUp() {
+        userDefaultsManager = UserDefaultsManager(
+            userDefaults: userDefaults,
+            jsonEncoder: JSONEncoder(),
+            jsonDecoder: JSONDecoder()
+        )
+    }
+    override func tearDown() {
+        // 등록된 모든 값 reset
+        userDefaults.removePersistentDomain(forName: "SNMPersistenceTests.UserDefaultsManager")
+    }
+
+    func test_set에서_Encodable한_타입을_저장할수_있다() throws {
+        // given
+        // when
+        // then
+        try userDefaultsManager.set(value: "hgd", forKey: "test")
+        try userDefaultsManager.set(value: Data(), forKey: "test")
+        try userDefaultsManager.set(value: 123, forKey: "test")
+    }
+    func test_get에서_Decodable한_타입을_읽어올수_있다() throws {
+        // given
+        try userDefaultsManager.set(value: "hgd", forKey: "test1")
+        try userDefaultsManager.set(value: Data(), forKey: "test2")
+        try userDefaultsManager.set(value: 123, forKey: "test3")
+        // when
+        let stringValue = try userDefaultsManager.get(forKey: "test1", type: String.self)
+        let dataValue =  try userDefaultsManager.get(forKey: "test2", type: Data.self)
+        let intValue = try userDefaultsManager.get(forKey: "test3", type: Int.self)
+        // then
+        XCTAssertEqual("hgd", stringValue)
+        XCTAssertEqual(Data(), dataValue)
+        XCTAssertEqual(123, intValue)
+    }
+    func test_get에서_지정한_디코딩_타입과_다르면_디코딩에러를_반환해야_한다() throws {
+        // given
+        try userDefaultsManager.set(value: "hgd", forKey: "test")
+        // when
+        // then
+        XCTAssertThrowsError(try userDefaultsManager.get(forKey: "test", type: Int.self)) { error in
+            XCTAssert(error is UserDefaultsError)
+            XCTAssertEqual(error as! UserDefaultsError, UserDefaultsError.decodingError)
+        }
+    }
+    func test_get에서_값이_존재할_때_값을_읽어올수_있다() throws {
+        // given
+        try userDefaultsManager.set(value: "hgd", forKey: "test")
+        // when
+        let value = try userDefaultsManager.get(forKey: "test", type: String.self)
+        // then
+        XCTAssertEqual(value, "hgd")
+    }
+    func test_get에서_값이_존재하지_않을때_notFound에러를_반환해야_한다() throws {
+        // given
+        // when
+        // then
+        XCTAssertThrowsError(try userDefaultsManager.get(forKey: "test", type: String.self)) { error in
+            XCTAssert(error is UserDefaultsError)
+            XCTAssertEqual(error as! UserDefaultsError, UserDefaultsError.notFound)
+        }
+    }
+    func test_set에서_key에_값이_존재하지_않을때_값이_설정되어야_한다() throws {
+        // given
+        // when
+        try userDefaultsManager.set(value: "hgd", forKey: "test")
+        // then
+        let value = try userDefaultsManager.get(forKey: "test", type: String.self)
+        XCTAssertEqual("hgd", value)
+    }
+    func test_set에서_key에_값이_이미_존재할때_값이_덮어씌워져야_한다() throws {
+        // given
+        try userDefaultsManager.set(value: "hgd", forKey: "test")
+        try userDefaultsManager.set(value: "sniffMeet", forKey: "test")
+        // when
+        let value = try userDefaultsManager.get(forKey: "test", type: String.self)
+        // then
+        XCTAssertEqual("sniffMeet", value)
+    }
+    func test_delete에서_key에_값이_존재하지_않을_때_noDeleteObject에러를_반환해야_한다() throws {
+        XCTAssertThrowsError(try userDefaultsManager.delete(forKey: "test")) { error in
+            XCTAssert(error is UserDefaultsError)
+            XCTAssertEqual(error as! UserDefaultsError, UserDefaultsError.noDeleteObject)
+        }
+    }
+    func test_delete에서_key에_값이_존재하면_값이_지워져야_한다() throws {
+        // given
+        try userDefaultsManager.set(value: "hgd", forKey: "test")
+        // when
+        try userDefaultsManager.delete(forKey: "test")
+        // then
+        let value = try? userDefaultsManager.get(forKey: "test", type: String.self)
+        XCTAssertNil(value)
+    }
+}

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -33,12 +33,28 @@
 		FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */; };
 		FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A03382CD8CF460047B7ED /* AppDelegate.swift */; };
 		FD3A03432CD8CF460047B7ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */; };
+		FD69B1B32CE3BC76009D71DC /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1B22CE3BC68009D71DC /* KeychainManager.swift */; };
+		FD69B1B52CE3BC7E009D71DC /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1B42CE3BC79009D71DC /* UserDefaultsManager.swift */; };
+		FD69B1C32CE3BCE4009D71DC /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1B42CE3BC79009D71DC /* UserDefaultsManager.swift */; };
+		FD69B1C42CE3BCE4009D71DC /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1B22CE3BC68009D71DC /* KeychainManager.swift */; };
+		FD69B1CB2CE3E9B4009D71DC /* UserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1CA2CE3E9B4009D71DC /* UserDefaultsTests.swift */; };
+		FD69B1CD2CE3E9BB009D71DC /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1CC2CE3E9B8009D71DC /* KeychainTests.swift */; };
 		FDBFA99F2CE1E50C00AA9220 /* SNMFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBFA99E2CE1E50900AA9220 /* SNMFont.swift */; };
 		FDBFA9A12CE1E51500AA9220 /* SNMColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBFA9A02CE1E51000AA9220 /* SNMColor.swift */; };
 		FDBFA9B12CE1FE5500AA9220 /* LayoutConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBFA9B02CE1FDED00AA9220 /* LayoutConstant.swift */; };
 		FDEAEA7A2CE3148D005890FA /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEAEA792CE3148C005890FA /* BaseView.swift */; };
 		FDEAEA7C2CE314A7005890FA /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEAEA7B2CE314A3005890FA /* BaseViewController.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		FD69B1BE2CE3BCDC009D71DC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FD3A03182CD8CDE50047B7ED /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FD3A031F2CD8CDE50047B7ED;
+			remoteInfo = SniffMeet;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		3200438A2CDF3BE900D08B6D /* ProfileSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSetupView.swift; sourceTree = "<group>"; };
@@ -61,6 +77,11 @@
 		FD3A033A2CD8CF460047B7ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FD3A033B2CD8CF460047B7ED /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		FD69B1B22CE3BC68009D71DC /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
+		FD69B1B42CE3BC79009D71DC /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
+		FD69B1BA2CE3BCDC009D71DC /* SNMPersistenceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SNMPersistenceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD69B1CA2CE3E9B4009D71DC /* UserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsTests.swift; sourceTree = "<group>"; };
+		FD69B1CC2CE3E9B8009D71DC /* KeychainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainTests.swift; sourceTree = "<group>"; };
 		FDBFA99E2CE1E50900AA9220 /* SNMFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMFont.swift; sourceTree = "<group>"; };
 		FDBFA9A02CE1E51000AA9220 /* SNMColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMColor.swift; sourceTree = "<group>"; };
 		FDBFA9B02CE1FDED00AA9220 /* LayoutConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConstant.swift; sourceTree = "<group>"; };
@@ -70,6 +91,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		FD3A031D2CD8CDE50047B7ED /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD69B1B72CE3BCDC009D71DC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -127,6 +155,7 @@
 			isa = PBXGroup;
 			children = (
 				FD3A033E2CD8CF460047B7ED /* SniffMeet */,
+				FD69B1C62CE3BCED009D71DC /* SNMPersistenceTests */,
 				FD3A03212CD8CDE50047B7ED /* Products */,
 			);
 			sourceTree = "<group>";
@@ -135,6 +164,7 @@
 			isa = PBXGroup;
 			children = (
 				FD3A03202CD8CDE50047B7ED /* SniffMeet.app */,
+				FD69B1BA2CE3BCDC009D71DC /* SNMPersistenceTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -146,6 +176,24 @@
 				FDA4912A2CD9FE3500A36FB0 /* Resource */,
 			);
 			path = SniffMeet;
+			sourceTree = "<group>";
+		};
+		FD69B1B12CE3BC55009D71DC /* Persistence */ = {
+			isa = PBXGroup;
+			children = (
+				FD69B1B42CE3BC79009D71DC /* UserDefaultsManager.swift */,
+				FD69B1B22CE3BC68009D71DC /* KeychainManager.swift */,
+			);
+			path = Persistence;
+			sourceTree = "<group>";
+		};
+		FD69B1C62CE3BCED009D71DC /* SNMPersistenceTests */ = {
+			isa = PBXGroup;
+			children = (
+				FD69B1CC2CE3E9B8009D71DC /* KeychainTests.swift */,
+				FD69B1CA2CE3E9B4009D71DC /* UserDefaultsTests.swift */,
+			);
+			path = SNMPersistenceTests;
 			sourceTree = "<group>";
 		};
 		FDA4912A2CD9FE3500A36FB0 /* Resource */ = {
@@ -161,6 +209,7 @@
 		FDA491332CD9FE7C00A36FB0 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				FD69B1B12CE3BC55009D71DC /* Persistence */,
 				A2C844CF2CDBE1CB007F2970 /* Common */,
 				FDA491392CD9FEC400A36FB0 /* App */,
 				A21435F52CE20CF600564A4D /* Tab */,
@@ -909,6 +958,26 @@
 			productReference = FD3A03202CD8CDE50047B7ED /* SniffMeet.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FD69B1B92CE3BCDC009D71DC /* SNMPersistenceTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FD69B1C02CE3BCDC009D71DC /* Build configuration list for PBXNativeTarget "SNMPersistenceTests" */;
+			buildPhases = (
+				FD69B1B62CE3BCDC009D71DC /* Sources */,
+				FD69B1B72CE3BCDC009D71DC /* Frameworks */,
+				FD69B1B82CE3BCDC009D71DC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FD69B1BF2CE3BCDC009D71DC /* PBXTargetDependency */,
+			);
+			name = SNMPersistenceTests;
+			packageProductDependencies = (
+			);
+			productName = SNMPersistenceTests;
+			productReference = FD69B1BA2CE3BCDC009D71DC /* SNMPersistenceTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -921,6 +990,10 @@
 				TargetAttributes = {
 					FD3A031F2CD8CDE50047B7ED = {
 						CreatedOnToolsVersion = 16.0;
+					};
+					FD69B1B92CE3BCDC009D71DC = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = FD3A031F2CD8CDE50047B7ED;
 					};
 				};
 			};
@@ -942,6 +1015,7 @@
 			projectRoot = "";
 			targets = (
 				FD3A031F2CD8CDE50047B7ED /* SniffMeet */,
+				FD69B1B92CE3BCDC009D71DC /* SNMPersistenceTests */,
 			);
 		};
 /* End PBXProject section */
@@ -954,6 +1028,13 @@
 				A288A63D2CDC595000D11C34 /* (null) in Resources */,
 				FD3A033F2CD8CF460047B7ED /* Assets.xcassets in Resources */,
 				FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD69B1B82CE3BCDC009D71DC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -977,6 +1058,7 @@
 				995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */,
 				A2F825D12CDF4BA6000C5419 /* HomeViewController.swift in Sources */,
 				320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */,
+				FD69B1B32CE3BC76009D71DC /* KeychainManager.swift in Sources */,
 				320043782CDCA49100D08B6D /* (null) in Sources */,
 				FDBFA9B12CE1FE5500AA9220 /* LayoutConstant.swift in Sources */,
 				320043912CDF3D7F00D08B6D /* KeywordButton.swift in Sources */,
@@ -989,9 +1071,21 @@
 				3200438B2CDF3BEF00D08B6D /* ProfileSetupView.swift in Sources */,
 				FDEAEA7A2CE3148D005890FA /* BaseView.swift in Sources */,
 				A2C328862CE245AC00D255AB /* TabBarModuleBuilder.swift in Sources */,
+				FD69B1B52CE3BC7E009D71DC /* UserDefaultsManager.swift in Sources */,
 				320043722CDC9E5F00D08B6D /* (null) in Sources */,
 				3200437C2CDCA6F300D08B6D /* (null) in Sources */,
 				320043702CDC9A0D00D08B6D /* (null) in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD69B1B62CE3BCDC009D71DC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD69B1CB2CE3E9B4009D71DC /* UserDefaultsTests.swift in Sources */,
+				FD69B1C32CE3BCE4009D71DC /* UserDefaultsManager.swift in Sources */,
+				FD69B1C42CE3BCE4009D71DC /* KeychainManager.swift in Sources */,
+				FD69B1CD2CE3E9BB009D71DC /* KeychainTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1001,6 +1095,11 @@
 		FD3A03472CD8D2C90047B7ED /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = FD3A03462CD8D2C90047B7ED /* SwiftLintBuildToolPlugin */;
+		};
+		FD69B1BF2CE3BCDC009D71DC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FD3A031F2CD8CDE50047B7ED /* SniffMeet */;
+			targetProxy = FD69B1BE2CE3BCDC009D71DC /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1199,6 +1298,42 @@
 			};
 			name = Release;
 		};
+		FD69B1C12CE3BCDC009D71DC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp9.SNMPersistenceTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SniffMeet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SniffMeet";
+			};
+			name = Debug;
+		};
+		FD69B1C22CE3BCDC009D71DC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp9.SNMPersistenceTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SniffMeet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SniffMeet";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1216,6 +1351,15 @@
 			buildConfigurations = (
 				FD3A03342CD8CDE60047B7ED /* Debug */,
 				FD3A03352CD8CDE60047B7ED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FD69B1C02CE3BCDC009D71DC /* Build configuration list for PBXNativeTarget "SNMPersistenceTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FD69B1C12CE3BCDC009D71DC /* Debug */,
+				FD69B1C22CE3BCDC009D71DC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SniffMeet/SniffMeet.xcodeproj/xcshareddata/xcschemes/SNMPersistenceTests.xcscheme
+++ b/SniffMeet/SniffMeet.xcodeproj/xcshareddata/xcschemes/SNMPersistenceTests.xcscheme
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FD69B1B92CE3BCDC009D71DC"
+               BuildableName = "SNMPersistenceTests.xctest"
+               BlueprintName = "SNMPersistenceTests"
+               ReferencedContainer = "container:SniffMeet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FD3A031F2CD8CDE50047B7ED"
+            BuildableName = "SniffMeet.app"
+            BlueprintName = "SniffMeet"
+            ReferencedContainer = "container:SniffMeet.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FD3A031F2CD8CDE50047B7ED"
+            BuildableName = "SniffMeet.app"
+            BlueprintName = "SniffMeet"
+            ReferencedContainer = "container:SniffMeet.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SniffMeet/SniffMeet.xcodeproj/xcshareddata/xcschemes/SniffMeet.xcscheme
+++ b/SniffMeet/SniffMeet.xcodeproj/xcshareddata/xcschemes/SniffMeet.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FD3A031F2CD8CDE50047B7ED"
+               BuildableName = "SniffMeet.app"
+               BlueprintName = "SniffMeet"
+               ReferencedContainer = "container:SniffMeet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FD69B1B92CE3BCDC009D71DC"
+               BuildableName = "SNMPersistenceTests.xctest"
+               BlueprintName = "SNMPersistenceTests"
+               ReferencedContainer = "container:SniffMeet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FD3A031F2CD8CDE50047B7ED"
+            BuildableName = "SniffMeet.app"
+            BlueprintName = "SniffMeet"
+            ReferencedContainer = "container:SniffMeet.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FD3A031F2CD8CDE50047B7ED"
+            BuildableName = "SniffMeet.app"
+            BlueprintName = "SniffMeet"
+            ReferencedContainer = "container:SniffMeet.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SniffMeet/SniffMeet/Source/Persistence/KeychainManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/KeychainManager.swift
@@ -1,0 +1,107 @@
+//
+//  KeychainManager.swift
+//  SniffMeet
+//
+//  Created by sole on 11/7/24.
+//
+
+import Foundation
+
+protocol KeychainManagable {
+    func get(forKey: String) throws -> String
+    func set(value: String, forKey: String) throws
+    func delete(forKey: String) throws
+}
+
+/// Keychain에 접근할 수 있는 싱글톤 인스턴스입니다.
+/// key, value 타입은 String으로 한정합니다.
+final class KeychainManager: KeychainManagable {
+    private init() {}
+
+    func get(forKey key: String) throws -> String {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecAttrAccount: key,
+            kSecReturnAttributes: true,
+            kSecReturnData: true
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard let existingItem = item as? [CFString: Any],
+              let valueData = existingItem[kSecValueData] as? Data,
+              let value = String(data: valueData, encoding: .utf8)
+        else {
+            throw KeychainError(rawValue: status) ?? .decodingError
+        }
+        return value
+    }
+    /// Keychain에 등록되지 않은 값의 경우 값을 생성합니다.
+    /// 이미 Keychain에 등록된 값의 경우 값을 업데이트합니다.
+    func set(value: String, forKey key: String) throws {
+        if (try? get(forKey: key)) != nil {
+            try update(value: value, forKey: key)
+        } else {
+            try create(key: key, value: value)
+        }
+    }
+    func delete(forKey key: String) throws {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        if let error = KeychainError(rawValue: status) {
+            throw error
+        }
+    }
+    private func create(key: String, value: String) throws {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecValueData: Data(value.utf8)
+        ]
+        let status = SecItemAdd(query as CFDictionary, nil)
+        if let error = KeychainError(rawValue: status) {
+            throw error
+        }
+    }
+    private func update(value: String, forKey key: String) throws {
+        let searchQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key
+        ]
+        let updateQuery: [CFString: Any] = [
+            kSecValueData: Data(value.utf8)
+        ]
+        let status = SecItemUpdate(searchQuery as CFDictionary, updateQuery as CFDictionary)
+        if let error = KeychainError(rawValue: status) {
+            throw error
+        }
+    }
+}
+
+// MARK: - KeychainManager+Singleton instance
+
+extension KeychainManager {
+    static let shared: KeychainManager = KeychainManager()
+}
+
+// MARK: - KeychainError
+
+/// Keychain에서 사용되는 OSStatus code 중 에러에 해당되는 부분과 일부 매핑됩니다.
+enum KeychainError: Int32, LocalizedError {
+    case alreadyExists = -25299
+    /// 지정된 키를 키체인에서 찾지 못함
+    case keyNotFound = -25300
+    /// 키체인이 존재하지 않을때, 권한 접근 오류
+    case keychainNotFound = -25294
+    /// query parameter가 잘못됨
+    case invalidParameter = -50
+    case encodingError = 100
+    case decodingError = 101
+
+    var errorDescription: String? {
+        SecCopyErrorMessageString(rawValue, nil) as? String
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Persistence/UserDefaultsManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/UserDefaultsManager.swift
@@ -1,0 +1,91 @@
+//
+//  UserDefaultsManager.swift
+//  SniffMeet
+//
+//  Created by sole on 11/7/24.
+//
+
+import Foundation
+
+protocol UserDefaultsManagable {
+    func get<T>(forKey: String, type: T.Type) throws -> T where T: Decodable
+    func set<T>(value: T, forKey: String) throws where T: Encodable
+    func delete(forKey: String) throws
+}
+
+/// UserDefaults를 관리하는 클래스입니다.
+/// 생성 시 userDefaults 파라미터에 아무것도 주입하지 않으면 standard를 기본으로 사용합니다.
+final class UserDefaultsManager: UserDefaultsManagable {
+    private let userDefaults: UserDefaults
+    private let jsonEncoder: JSONEncoder
+    private let jsonDecoder: JSONDecoder
+
+    init(
+        userDefaults: UserDefaults = .standard,
+        jsonEncoder: JSONEncoder,
+        jsonDecoder: JSONDecoder
+    ) {
+        self.userDefaults = userDefaults
+        self.jsonEncoder = jsonEncoder
+        self.jsonDecoder = jsonDecoder
+    }
+
+    /// 값이 UserDefaults에 없는 경우 nil을 반환합니다.
+    func get<T>(forKey key: String, type: T.Type) throws -> T where T: Decodable {
+        guard let data = userDefaults.data(forKey: key)
+        else {
+            throw UserDefaultsError.notFound
+        }
+
+        do {
+            let decodedValue = try jsonDecoder.decode(type, from: data)
+            return decodedValue
+        } catch {
+            throw UserDefaultsError.decodingError
+        }
+    }
+    func set<T: Encodable>(value: T, forKey: String) throws where T: Encodable {
+        do {
+            let encodedData = try jsonEncoder.encode(value)
+            userDefaults.setValue(encodedData, forKey: forKey)
+        } catch {
+            throw UserDefaultsError.encodingError
+        }
+    }
+    func delete(forKey key: String) throws {
+        if userDefaults.data(forKey: key) != nil {
+            userDefaults.removeObject(forKey: key)
+        } else {
+            throw UserDefaultsError.noDeleteObject
+        }
+    }
+}
+
+// MARK: - UserDefaultsManager+Singleton instance
+
+extension UserDefaultsManager {
+    /// UserDefaultsManager 싱글톤 인스턴스입니다. 내부적으로 UserDefaults.standard를 사용합니다.
+    static let shared: UserDefaultsManager = UserDefaultsManager(
+        userDefaults: .standard,
+        jsonEncoder: JSONEncoder(),
+        jsonDecoder: JSONDecoder()
+    )
+}
+
+// MARK: - UserDefaultsError
+
+enum UserDefaultsError: LocalizedError {
+    case notFound
+    case encodingError
+    case decodingError
+    case noDeleteObject
+
+    var errorDescription: String? {
+        switch self {
+        case .notFound: "key에 대한 값을 찾을 수 없습니다."
+        case .encodingError: "인코딩 에러"
+        case .decodingError: "디코딩 에러"
+        case .noDeleteObject: "삭제할 대상을 찾을 수 없습니다."
+        }
+    }
+}


### PR DESCRIPTION
### 🔖  Issue Number

close #42 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 

- KeychainManager를 구현했습니다. 
앱에서 여러개의 Keychain을 사용할 가능성이 없다고 판단해 싱글톤으로 구현했습니다. (사용시 싱글톤 인스턴스인 shared를 사용하시면 됩니다.)
우리 프로젝트에서 Keychain이 사용되는 용도가 access_token을 단순히 저장하는 정도라서 **key, value의 타입은 모두 String으로 제한**했습니다.

인터페이스는 아래와 같습니다. 
``` swift 
protocol KeychainManagable {
    func get(forKey: String) throws -> String
    func set(value: String, forKey: String) throws
    func delete(forKey: String) throws
}
```

- UserDefaultsManager를 구현했습니다. 
UserDefaultsManager는 Keychain과 다르게 여러 개를 사용할 가능성이 있다고 생각했습니다. 그래서 싱글톤(shared)을 두되, 생성자도 internal로 열었습니다. 
UserDefaultsManagable의 경우 Encodable한 데이터를 value로 받도록 했습니다. 따라서 내부에서 사용되는 인디코더를 생성자를 통해 JSON En/Decoder를 주입할 수 있도록 했습니다. 

``` swift 
init(
        userDefaults: UserDefaults = .standard,
        jsonEncoder: JSONEncoder,
        jsonDecoder: JSONDecoder
    ) {
        self.userDefaults = userDefaults
        self.jsonEncoder = jsonEncoder
        self.jsonDecoder = jsonDecoder
    }
```

인터페이스는 아래와 같습니다. 
**주의해야 할점은 저장한 데이터의 타입을 불러올 때(get) 정확하게 데이터 타입을 지정해주어야 에러가 발생하지 않습니다.** (아니면 디코딩 에러가 발생합니다.) 그런데 이 방식이 조금 불편할까 염려되긴 하더라구요... 이 부분 괜찮은지 의견 부탁드립니다~~
``` swift 
protocol UserDefaultsManagable {
    func get<T>(forKey: String, type: T.Type) throws -> T where T: Decodable
    func set<T>(value: T, forKey: String) throws where T: Encodable
    func delete(forKey: String) throws
}
```

- Keychain / UserDefaults 테스트를 진행했습니다. 
Test는 실제 Keychain, UserDefaults 환경에서 수행했습니다. 
protocol을 정의해두었기 때문에 MockKeychain, MockUserDefaults로 테스트를 진행할지 고민했는데요. 아래와 같이 Mock이 만들어지더라구요. 
``` swift 
final class MockKeychain: KeychainManagable {
	private var container: [String: String] = [:]

	func get(forKey: String) throws -> String {
			guard let value = container[key] else { throw KeychainError.keyNotFound }
			return value 
	}
	// ,,, 중략 
}

```
사실상 딕셔너리 기능 테스트랑 별반 다를게 없어서 Mock 객체 테스트가 의미없다 판단하고 실제 환경에서 테스트 진행했습니다~

![image](https://github.com/user-attachments/assets/f7190704-63d7-4f46-a617-bd0b72491041)
