### PR TITLE
[feat] MPCAdvertiser, MPCBrowser, MPConnectionManager 구현 

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -19,9 +19,12 @@
 		320043942CDF3D7F00D08B6D /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043902CDF3D7F00D08B6D /* PrimaryButton.swift */; };
 		320043952CDF3D7F00D08B6D /* Extension + Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200438C2CDF3D7F00D08B6D /* Extension + Navigation.swift */; };
 		320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320043962CDF493600D08B6D /* Extension + UIView.swift */; };
-		A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21435F62CE20D2500564A4D /* TabBarController.swift */; };
+		3200441A2CE48A3D00D08B6D /* MPCBroswer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320044192CE48A3100D08B6D /* MPCBroswer.swift */; };
+		3200441C2CE48C5C00D08B6D /* MPCAdvertiser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200441B2CE48C5600D08B6D /* MPCAdvertiser.swift */; };
+		3200441E2CE48D3500D08B6D /* MPConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200441D2CE48D1F00D08B6D /* MPConnectionManager.swift */; };
 		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
 		99FA4E792CE0FBBF00553C2E /* ProfileInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA4E782CE0FBBF00553C2E /* ProfileInputView.swift */; };
+		A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21435F62CE20D2500564A4D /* TabBarController.swift */; };
 		A288A63D2CDC595000D11C34 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		A2C328862CE245AC00D255AB /* TabBarModuleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328852CE245AC00D255AB /* TabBarModuleBuilder.swift */; };
 		A2C328882CE2481900D255AB /* HomeModuleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328872CE2481900D255AB /* HomeModuleBuilder.swift */; };
@@ -48,11 +51,14 @@
 		3200438F2CDF3D7F00D08B6D /* KeywordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordView.swift; sourceTree = "<group>"; };
 		320043902CDF3D7F00D08B6D /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
 		320043962CDF493600D08B6D /* Extension + UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIView.swift"; sourceTree = "<group>"; };
+		320044192CE48A3100D08B6D /* MPCBroswer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPCBroswer.swift; sourceTree = "<group>"; };
+		3200441B2CE48C5600D08B6D /* MPCAdvertiser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPCAdvertiser.swift; sourceTree = "<group>"; };
+		3200441D2CE48D1F00D08B6D /* MPConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPConnectionManager.swift; sourceTree = "<group>"; };
+		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
+		99FA4E782CE0FBBF00553C2E /* ProfileInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputView.swift; sourceTree = "<group>"; };
 		A21435F62CE20D2500564A4D /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		A2C328852CE245AC00D255AB /* TabBarModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarModuleBuilder.swift; sourceTree = "<group>"; };
 		A2C328872CE2481900D255AB /* HomeModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModuleBuilder.swift; sourceTree = "<group>"; };
-		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
-		99FA4E782CE0FBBF00553C2E /* ProfileInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputView.swift; sourceTree = "<group>"; };
 		A2F825D02CDF4BA6000C5419 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		A2F825DC2CDFBEB4000C5419 /* ProfileCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCardView.swift; sourceTree = "<group>"; };
 		FD3A03202CD8CDE50047B7ED /* SniffMeet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SniffMeet.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -79,6 +85,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		320044172CE489A900D08B6D /* LocalNetwork */ = {
+			isa = PBXGroup;
+			children = (
+				320044182CE48A1900D08B6D /* MPC */,
+			);
+			path = LocalNetwork;
+			sourceTree = "<group>";
+		};
+		320044182CE48A1900D08B6D /* MPC */ = {
+			isa = PBXGroup;
+			children = (
+				3200441D2CE48D1F00D08B6D /* MPConnectionManager.swift */,
+				3200441B2CE48C5600D08B6D /* MPCAdvertiser.swift */,
+				320044192CE48A3100D08B6D /* MPCBroswer.swift */,
+			);
+			path = MPC;
+			sourceTree = "<group>";
+		};
 		A21435F52CE20CF600564A4D /* Tab */ = {
 			isa = PBXGroup;
 			children = (
@@ -169,6 +193,7 @@
 				FDA4913C2CDA056400A36FB0 /* Walk */,
 				FDA4913E2CDA05F900A36FB0 /* Mate */,
 				FDA4913A2CDA04BB00A36FB0 /* Repository */,
+				320044172CE489A900D08B6D /* LocalNetwork */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -975,6 +1000,7 @@
 				A2F825DD2CDFBEB4000C5419 /* ProfileCardView.swift in Sources */,
 				A2C328882CE2481900D255AB /* HomeModuleBuilder.swift in Sources */,
 				995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */,
+				3200441C2CE48C5C00D08B6D /* MPCAdvertiser.swift in Sources */,
 				A2F825D12CDF4BA6000C5419 /* HomeViewController.swift in Sources */,
 				320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */,
 				320043782CDCA49100D08B6D /* (null) in Sources */,
@@ -990,6 +1016,8 @@
 				FDEAEA7A2CE3148D005890FA /* BaseView.swift in Sources */,
 				A2C328862CE245AC00D255AB /* TabBarModuleBuilder.swift in Sources */,
 				320043722CDC9E5F00D08B6D /* (null) in Sources */,
+				3200441E2CE48D3500D08B6D /* MPConnectionManager.swift in Sources */,
+				3200441A2CE48A3D00D08B6D /* MPCBroswer.swift in Sources */,
 				3200437C2CDCA6F300D08B6D /* (null) in Sources */,
 				320043702CDC9A0D00D08B6D /* (null) in Sources */,
 			);
@@ -1026,6 +1054,7 @@
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SniffMeet/Resource/Info.plist;
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "메이트 맺기 기능에는 로컬 네트워크 사용이 필요합니다.  \\n 로컬 네트워크를 사용하시겠습니까?";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -1058,6 +1087,7 @@
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SniffMeet/Resource/Info.plist;
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "메이트 맺기 기능에는 로컬 네트워크 사용이 필요합니다.  \\n 로컬 네트워크를 사용하시겠습니까?";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;

--- a/SniffMeet/SniffMeet/Resource/Info.plist
+++ b/SniffMeet/SniffMeet/Resource/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_SniffMeet._tcp</string>
+		<string>_SniffMeet._udp</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
@@ -1,0 +1,71 @@
+//
+//  MPCAdvertiser.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 11/13/24.
+//
+import MultipeerConnectivity
+import os
+
+fileprivate let log = Logger()
+
+final class MPCAdvertiser: NSObject {
+    let advertiser: MCNearbyServiceAdvertiser
+    let session: MCSession
+    let myPeerID: MCPeerID
+
+    @Published var receivedInvite: Bool = false
+    @Published var receivedInviteFrom: MCPeerID?
+    @Published var invitationHandler: ((Bool, MCSession?) -> Void)?
+
+    init(advertiser: MCNearbyServiceAdvertiser,
+         session: MCSession,
+         myPeerID: MCPeerID,
+         receivedInviteFrom: MCPeerID? = nil,
+         invitationHandler: ((Bool, MCSession?) -> Void)? = nil)
+    {
+        self.advertiser = advertiser
+        self.session = session
+        self.myPeerID = myPeerID
+        self.receivedInviteFrom = receivedInviteFrom
+        self.invitationHandler = invitationHandler
+        
+        super.init()
+        advertiser.delegate = self
+    }
+    
+    convenience init(session: MCSession, myPeerID: MCPeerID, serviceType: String) {
+        /// 이렇게 메타데이터와 함께 advertiser를 만들면 advertising할 때 정보 전달 가능
+        ///let advertiser = MCNearbyServiceAdvertiser(peer: myPeerID, discoveryInfo: discoveryInfo, serviceType: "my-service")
+        self.init(advertiser: MCNearbyServiceAdvertiser(peer: myPeerID,
+                                                        discoveryInfo: nil,
+                                                        serviceType: serviceType),
+                  session: session,
+                  myPeerID: myPeerID)
+    }
+    
+    func startAdvertising() {
+        advertiser.startAdvertisingPeer()
+        log.log("start advertising")
+    }
+    
+    func stopAdvertising() {
+        advertiser.stopAdvertisingPeer()
+        log.log("stop advertising")
+    }
+}
+
+extension MPCAdvertiser: MCNearbyServiceAdvertiserDelegate {
+    func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
+                    didReceiveInvitationFromPeer peerID: MCPeerID,
+                    withContext context: Data?,
+                    invitationHandler: @escaping (Bool, MCSession?) -> Void)
+    {
+        self.receivedInvite = true
+        self.receivedInviteFrom = peerID
+        self.invitationHandler = invitationHandler
+        
+        invitationHandler(true, session)
+    }
+}
+

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
@@ -48,8 +48,8 @@ final class MPCBrowser: NSObject {
     }
     
     func invite() {
-        guard availablePeers.isEmpty else { return }
-        browser.invitePeer(availablePeers[0], to: session, withContext: nil, timeout: 10)
+        guard let peer = availablePeers.first else { return }
+        browser.invitePeer(peer, to: session, withContext: nil, timeout: 10)
     }
     
     func invite(peerID: MCPeerID) {

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
@@ -72,7 +72,7 @@ extension MPCBrowser: MCNearbyServiceBrowserDelegate {
         
         // info에 해당되는 peer에 대해서만 availablepeers에 넣을 수 있다
         log.info("ServiceBrowser found peer: \(peerID)")
-        guard self.availablePeers.contains(peerID) == false else { return }
+        guard !(self.availablePeers.contains(peerID)) else { return }
         self.availablePeers.append(peerID)
     }
     

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
@@ -1,0 +1,85 @@
+//
+//  MPCBroswer.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 11/13/24.
+//
+import MultipeerConnectivity
+import os
+
+fileprivate let log = Logger()
+
+final class MPCBrowser: NSObject {
+    let browser: MCNearbyServiceBrowser
+    let session: MCSession
+    let myPeerId: MCPeerID
+    
+    @Published var paired: Bool = false
+    @Published var availablePeers = [MCPeerID]()
+    
+    init(browser: MCNearbyServiceBrowser,
+         session: MCSession,
+         myPeerId: MCPeerID)
+    {
+        self.browser = browser
+        self.session = session
+        self.myPeerId = myPeerId
+        
+        super.init()
+        browser.delegate = self
+    }
+    
+    convenience init(session: MCSession, myPeerID: MCPeerID, serviceType: String) {
+        self.init(browser: MCNearbyServiceBrowser(peer: myPeerID, serviceType: serviceType),
+                  session: session,
+                  myPeerId: myPeerID)
+    }
+    
+    func startBrowsing() {
+        browser.startBrowsingForPeers()
+        log.log("start Browsing")
+
+    }
+    
+    func stopBrowsing() {
+        browser.stopBrowsingForPeers()
+        availablePeers.removeAll()
+        log.log("stop Browsing")
+    }
+    
+    func invite() {
+        guard availablePeers.isEmpty else { return }
+        browser.invitePeer(availablePeers[0], to: session, withContext: nil, timeout: 10)
+    }
+    
+    func invite(peerID: MCPeerID) {
+        browser.invitePeer(peerID, to: session, withContext: nil, timeout: 10)
+    }
+    
+    func invite(peerID: MCPeerID, tokenData: Data) {
+        browser.invitePeer(peerID, to: session, withContext: tokenData, timeout: 10)
+    }
+}
+
+extension MPCBrowser: MCNearbyServiceBrowserDelegate {
+    func browser(_ browser: MCNearbyServiceBrowser,
+                 foundPeer peerID: MCPeerID,
+                 withDiscoveryInfo info: [String : String]?)
+    {
+        if let info = info {
+            print("Found peer with info: \(info)")
+        }
+        
+        // info에 해당되는 peer에 대해서만 availablepeers에 넣을 수 있다
+        log.info("ServiceBrowser found peer: \(peerID)")
+        guard self.availablePeers.contains(peerID) == false else { return }
+        self.availablePeers.append(peerID)
+    }
+    
+    
+    func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        guard let index = availablePeers.firstIndex(of: peerID) else { return }
+        self.availablePeers.remove(at: index)
+    }
+}
+

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPConnectionManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPConnectionManager.swift
@@ -17,7 +17,7 @@ final class MPCManager: NSObject {
     let browser: MPCBrowser
     let session: MCSession
     let mypeerID: MCPeerID
-    var connectedPeers: MCPeerID?
+    var connectedPeers = [MCPeerID]()
     
     @Published var paired: Bool = false
     @Published var receivedData: Data?

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPConnectionManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPConnectionManager.swift
@@ -1,0 +1,124 @@
+//
+//  MPConnectionManager.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 11/13/24.
+//
+import MultipeerConnectivity
+import os
+
+extension String {
+    static var serviceName = "SniffMeet"
+}
+
+final class MPCManager: NSObject {
+    let advertiser: MPCAdvertiser
+    let browser: MPCBrowser
+    let session: MCSession
+    let mypeerID: MCPeerID
+    var connectedPeers: MCPeerID?
+    
+    @Published var paired: Bool = false
+    @Published var receivedData: Data?
+    private let log = Logger()
+
+    var isAvailableToBeConnected: Bool = false {
+        didSet {
+            if isAvailableToBeConnected {
+                advertiser.startAdvertising()
+            } else {
+                advertiser.stopAdvertising()
+            }
+        }
+    }
+    
+    init(advertiser: MPCAdvertiser, browser: MPCBrowser, session: MCSession, mypeerID: MCPeerID) {
+        self.advertiser = advertiser
+        self.browser = browser
+        self.session = session
+        self.mypeerID = mypeerID
+       
+        super.init()
+
+        session.delegate = self
+    }
+    
+    convenience init(yourName: String) {
+        let peerID = MCPeerID(displayName: yourName)
+        let serviceType = String.serviceName
+        let session = MCSession(peer: peerID)
+        
+        self.init(advertiser: MPCAdvertiser(session: session,
+                                            myPeerID: peerID,
+                                            serviceType: serviceType),
+                  browser:  MPCBrowser(session: session,
+                                       myPeerID: peerID,
+                                       serviceType: serviceType),
+                  session: session,
+                  mypeerID: peerID)
+    }
+    
+    deinit {
+        advertiser.stopAdvertising()
+        browser.stopBrowsing()
+    }
+    
+    func send(mateData: Codable) {
+        if !session.connectedPeers.isEmpty {
+            do {
+                if let data =  try? JSONEncoder().encode(mateData) {
+                    try session.send(data, toPeers: session.connectedPeers, with: .reliable)
+                }
+            } catch {
+                print("error sending \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+// MARK: - MCSessionDelegate
+extension MPCManager: MCSessionDelegate {
+    func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        log.info("peer \(peerID) didChangeState: \(state.rawValue)")
+        switch state {
+        case .notConnected:
+            Task { @MainActor in
+                self.paired = false
+                self.isAvailableToBeConnected = true
+            }
+        case .connected:
+            Task { @MainActor in
+                self.paired = true
+                self.isAvailableToBeConnected = false
+            }
+        default:
+            Task { @MainActor in
+                self.paired = false
+                self.isAvailableToBeConnected = true
+            }
+        }
+    }
+
+    func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        log.info("didReceive bytes \(data.count) bytes")
+        Task { @MainActor in
+            // interactor에 mate 요청 데이터를 보내고
+            receivedData = data
+            self.session.disconnect()
+            self.isAvailableToBeConnected = true
+        }
+    }
+
+    func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {
+        log.error("Receiving streams is not supported")
+    }
+
+    func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {
+        log.error("Receiving resources is not supported")
+    }
+
+    func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: (any Error)?) {
+        log.error("Receiving resources is not supported")
+    }
+}
+

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPConnectionManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPConnectionManager.swift
@@ -6,6 +6,7 @@
 //
 import MultipeerConnectivity
 import os
+import NearbyInteraction
 
 extension String {
     static var serviceName = "SniffMeet"
@@ -63,7 +64,7 @@ final class MPCManager: NSObject {
         browser.stopBrowsing()
     }
     
-    func send(mateData: Codable) {
+    func send(mateData: Encodable) {
         if !session.connectedPeers.isEmpty {
             do {
                 if let data =  try? JSONEncoder().encode(mateData) {


### PR DESCRIPTION
### 🔖  Issue Number

close #45 

### 📙 작업 내역


>  MultipeerConnectivity를 활용하여 p2p 연결을 수행하고 데이터를 송수신할 수 있도록 만들었습니다. 
- [x]  MPC에서 Advertiser 역할을 맡는 MPCAdvertiser 구현
- [x] MPC에서 Browser 역할을 맡는 MPCBrowser 구현
- [x] Advertiser, Browser를 소유하고 있고 session을 관리하는 MPConnectionManager 구현 

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1: MPConnectionManager가 advertising, browsing 역할 모두 수행 
피어에게 advertiser, browser 둘 중 하나의 역할 부여가 어렵기 때문에 MPConnectionManager가 advertiser, browser를 소유하여 두 역할 모두 수행하게끔 구현했습니다. 

- 특이 사항 2: 현재 browsing된 주변 모든 peer 기록 
```swift
final class MPCBrowser:NSObject {
    ...
    @Published var availablePeers = [MCPeerID]()

extension MPCBrowser: MCNearbyServiceBrowserDelegate {
    func browser(_ browser: MCNearbyServiceBrowser,
                 foundPeer peerID: MCPeerID,
                 withDiscoveryInfo info: [String : String]?)
    {
        log.info("ServiceBrowser found peer: \(peerID)")
        guard self.availablePeers.contains(peerID) == false else { return }
        self.availablePeers.append(peerID)
    }
    
    func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
        guard let index = availablePeers.firstIndex(of: peerID) else { return }
        self.availablePeers.remove(at: index)
    }
}
```
현재는 모두 연결가능한 피어 배열을 통해서 기록했지만 추후 NBI를 이용해서 확인된 peer에 대해서만 추가하도록 수정이 필요할 거 같습니다. 

advertiser를 생성할 때 discoveryInfo에 특정 정보와 함께 advertising을 진행합니다. browser는 특정 정보를 가진 peer에 대해서만 availablePeers 목록에 추가하도록 로직을 수정할 계획입니다. 
```swift
MCNearbyServiceAdvertiser(peer: myPeerID, discoveryInfo: nil, serviceType: serviceType)
```

### 👻 레퍼런스
- 참고한 자료
https://developer.apple.com/documentation/multipeerconnectivity
http://hidavidbae.blogspot.com/2014/01/ios7-multipeer-connectivity-framework.html

- MultipeerConnectivity 학습 정리한 자료 
https://check-it.notion.site/Multipeer-Connectivity-1045b4317bde455096dee791942cc914?pvs=4

