### PR TITLE
[feat] SNMNetwork 구현

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		A2C844D72CDBEF8B007F2970 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		A2F825D12CDF4BA6000C5419 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F825D02CDF4BA6000C5419 /* HomeViewController.swift */; };
 		A2F825DD2CDFBEB4000C5419 /* ProfileCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F825DC2CDFBEB4000C5419 /* ProfileCardView.swift */; };
+		FD0634262CE596B5003C9D6B /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634252CE596B2003C9D6B /* Endpoint.swift */; };
+		FD0634282CE596BD003C9D6B /* SNMRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634272CE596BA003C9D6B /* SNMRequestConvertible.swift */; };
+		FD06342A2CE596D0003C9D6B /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634292CE596C2003C9D6B /* NetworkProvider.swift */; };
+		FD06342C2CE5984D003C9D6B /* SNMNetworkResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD06342B2CE59843003C9D6B /* SNMNetworkResponse.swift */; };
 		FD3A033F2CD8CF460047B7ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FD3A03392CD8CF460047B7ED /* Assets.xcassets */; };
 		FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */; };
 		FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A03382CD8CF460047B7ED /* AppDelegate.swift */; };
@@ -79,6 +83,10 @@
 		A2C328912CE3BEA000D255AB /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
 		A2F825D02CDF4BA6000C5419 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		A2F825DC2CDFBEB4000C5419 /* ProfileCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCardView.swift; sourceTree = "<group>"; };
+		FD0634252CE596B2003C9D6B /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
+		FD0634272CE596BA003C9D6B /* SNMRequestConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMRequestConvertible.swift; sourceTree = "<group>"; };
+		FD0634292CE596C2003C9D6B /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
+		FD06342B2CE59843003C9D6B /* SNMNetworkResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMNetworkResponse.swift; sourceTree = "<group>"; };
 		FD3A03202CD8CDE50047B7ED /* SniffMeet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SniffMeet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD3A03382CD8CF460047B7ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FD3A03392CD8CF460047B7ED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -177,6 +185,17 @@
 			path = Common;
 			sourceTree = "<group>";
 		};
+		FD0634242CE596A7003C9D6B /* SNMNetwork */ = {
+			isa = PBXGroup;
+			children = (
+				FD0634292CE596C2003C9D6B /* NetworkProvider.swift */,
+				FD0634272CE596BA003C9D6B /* SNMRequestConvertible.swift */,
+				FD0634252CE596B2003C9D6B /* Endpoint.swift */,
+				FD06342B2CE59843003C9D6B /* SNMNetworkResponse.swift */,
+			);
+			path = SNMNetwork;
+			sourceTree = "<group>";
+		};
 		FD3A03172CD8CDE50047B7ED = {
 			isa = PBXGroup;
 			children = (
@@ -235,6 +254,7 @@
 		FDA491332CD9FE7C00A36FB0 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				FD0634242CE596A7003C9D6B /* SNMNetwork */,
 				FD69B1B12CE3BC55009D71DC /* Persistence */,
 				A2C844CF2CDBE1CB007F2970 /* Common */,
 				FDA491392CD9FEC400A36FB0 /* App */,
@@ -1086,13 +1106,17 @@
 				995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */,
 				3200441C2CE48C5C00D08B6D /* MPCAdvertiser.swift in Sources */,
 				A2F825D12CDF4BA6000C5419 /* HomeViewController.swift in Sources */,
+				FD0634282CE596BD003C9D6B /* SNMRequestConvertible.swift in Sources */,
 				320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */,
+				FD0634262CE596B5003C9D6B /* Endpoint.swift in Sources */,
 				FD69B1B32CE3BC76009D71DC /* KeychainManager.swift in Sources */,
 				320043782CDCA49100D08B6D /* (null) in Sources */,
+				FD06342A2CE596D0003C9D6B /* NetworkProvider.swift in Sources */,
 				FDBFA9B12CE1FE5500AA9220 /* LayoutConstant.swift in Sources */,
 				320043912CDF3D7F00D08B6D /* KeywordButton.swift in Sources */,
 				320043922CDF3D7F00D08B6D /* InputTextField.swift in Sources */,
 				320043932CDF3D7F00D08B6D /* KeywordView.swift in Sources */,
+				FD06342C2CE5984D003C9D6B /* SNMNetworkResponse.swift in Sources */,
 				320043942CDF3D7F00D08B6D /* PrimaryButton.swift in Sources */,
 				320043952CDF3D7F00D08B6D /* Extension + Navigation.swift in Sources */,
 				FDBFA99F2CE1E50C00AA9220 /* SNMFont.swift in Sources */,

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		FD0634282CE596BD003C9D6B /* SNMRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634272CE596BA003C9D6B /* SNMRequestConvertible.swift */; };
 		FD06342A2CE596D0003C9D6B /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634292CE596C2003C9D6B /* NetworkProvider.swift */; };
 		FD06342C2CE5984D003C9D6B /* SNMNetworkResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD06342B2CE59843003C9D6B /* SNMNetworkResponse.swift */; };
+		FD0634312CE62578003C9D6B /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634302CE62573003C9D6B /* AnyEncodable.swift */; };
 		FD3A033F2CD8CF460047B7ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FD3A03392CD8CF460047B7ED /* Assets.xcassets */; };
 		FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */; };
 		FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A03382CD8CF460047B7ED /* AppDelegate.swift */; };
@@ -87,6 +88,7 @@
 		FD0634272CE596BA003C9D6B /* SNMRequestConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMRequestConvertible.swift; sourceTree = "<group>"; };
 		FD0634292CE596C2003C9D6B /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
 		FD06342B2CE59843003C9D6B /* SNMNetworkResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMNetworkResponse.swift; sourceTree = "<group>"; };
+		FD0634302CE62573003C9D6B /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		FD3A03202CD8CDE50047B7ED /* SniffMeet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SniffMeet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD3A03382CD8CF460047B7ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FD3A03392CD8CF460047B7ED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 		FD0634242CE596A7003C9D6B /* SNMNetwork */ = {
 			isa = PBXGroup;
 			children = (
+				FD0634302CE62573003C9D6B /* AnyEncodable.swift */,
 				FD0634292CE596C2003C9D6B /* NetworkProvider.swift */,
 				FD0634272CE596BA003C9D6B /* SNMRequestConvertible.swift */,
 				FD0634252CE596B2003C9D6B /* Endpoint.swift */,
@@ -1127,6 +1130,7 @@
 				FD69B1B52CE3BC7E009D71DC /* UserDefaultsManager.swift in Sources */,
 				320043722CDC9E5F00D08B6D /* (null) in Sources */,
 				3200441E2CE48D3500D08B6D /* MPConnectionManager.swift in Sources */,
+				FD0634312CE62578003C9D6B /* AnyEncodable.swift in Sources */,
 				3200441A2CE48A3D00D08B6D /* MPCBroswer.swift in Sources */,
 				3200437C2CDCA6F300D08B6D /* (null) in Sources */,
 				A2C328922CE3BEA000D255AB /* AppRouter.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/SNMNetwork/AnyEncodable.swift
+++ b/SniffMeet/SniffMeet/Source/SNMNetwork/AnyEncodable.swift
@@ -1,0 +1,26 @@
+//
+//  AnyEncodable.swift
+//  SniffMeet
+//
+//  Created by sole on 11/14/24.
+//
+
+import Foundation
+
+struct AnyEncodable {
+    private let jsonEncoder: JSONEncoder
+    private let value: any Encodable
+    
+    init(_ value: any Encodable, jsonEncoder: JSONEncoder = AnyEncodable.defaultJSONEncoder) {
+        self.value = value
+        self.jsonEncoder = jsonEncoder
+    }
+    
+    func encode() throws -> Data {
+        try jsonEncoder.encode(value)
+    }
+}
+
+extension AnyEncodable {
+    static let defaultJSONEncoder: JSONEncoder = JSONEncoder()
+}

--- a/SniffMeet/SniffMeet/Source/SNMNetwork/Endpoint.swift
+++ b/SniffMeet/SniffMeet/Source/SNMNetwork/Endpoint.swift
@@ -1,0 +1,37 @@
+//
+//  EndPoint.swift
+//  HGDNetwork
+//
+//  Created by 윤지성 on 11/7/24.
+//
+
+import Foundation
+
+public struct Endpoint {
+    public var baseURL: URL
+    public var path: String
+    public var method: HTTPMethod
+    public var query: [String: String]?
+    /// path와 query를 조합한 URL입니다. 조합에 실패시 baseURL을 반환합니다. 
+    public var absoluteURL: URL  {
+        var absoluteURLString: String = baseURL.absoluteString + "/"
+        // 의미없는 / 제거
+        let pathComponents = path.components(separatedBy: "/")
+                                .compactMap{ $0.isEmpty ? nil : $0 }
+        let queryPathString: String = query?.map{ "\($0)=\($1)" }.joined(separator: "&") ?? ""
+        absoluteURLString += pathComponents.joined(separator: "/")
+        if !queryPathString.isEmpty {
+            absoluteURLString += "?\(queryPathString)"
+        }
+    
+        return URL(string: absoluteURLString) ?? baseURL
+    }
+}
+
+public enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case delete = "DELETE"
+    case put = "PUT"
+    case patch = "PATCH"
+}

--- a/SniffMeet/SniffMeet/Source/SNMNetwork/NetworkProvider.swift
+++ b/SniffMeet/SniffMeet/Source/SNMNetwork/NetworkProvider.swift
@@ -1,0 +1,118 @@
+//
+//  Provider.swift
+//  HGDNetwork
+//
+//  Created by 윤지성 on 11/7/24.
+//
+
+import Foundation
+
+protocol NetworkProvider {
+    func request(with: any SNMRequestConvertible) async throws -> SNMNetworkResponse
+}
+
+public final class SNMNetworkProvider: NetworkProvider {
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func request(
+        with request: any SNMRequestConvertible
+    ) async throws -> SNMNetworkResponse {
+        let (data, response) = try await session.data(for: request.urlRequest())
+        guard let httpResponse = response as? HTTPURLResponse
+        else { throw SNMNetworkError.invalidResponse(response: response) }
+        try mapHttpStatusCode(statusCode: httpResponse.statusCode)
+        let snmResponse = SNMNetworkResponse(statusCode: httpResponse.statusCode, data: data)
+        return snmResponse
+    }
+    /// HTTPStatusCode에 따라 SNMNetworkError로 변경합니다.
+    private func mapHttpStatusCode(statusCode: Int) throws {
+        switch statusCode {
+        case 200...299: break
+        case 300...399:
+            throw SNMNetworkError.redirection
+        case 400:
+            throw SNMNetworkError.badRequest
+        case 401:
+            throw SNMNetworkError.unAuthorization
+        case 403:
+            throw SNMNetworkError.forbidden
+        case 404:
+            throw SNMNetworkError.notFound
+        case 405:
+            throw SNMNetworkError.methodNotAllowed
+        case 413:
+            throw SNMNetworkError.contentTooLarge
+        case 414:
+            throw SNMNetworkError.urlTooLong
+        case 415:
+            throw SNMNetworkError.unsupportMediaType
+        case 500...599:
+            throw SNMNetworkError.serverError
+        default:
+            throw SNMNetworkError.invalidStatusCode(statusCode: statusCode)
+        }
+    }
+}
+
+public enum SNMNetworkError: LocalizedError {
+    // SNMNetwork Error
+    case encodingError(with: any Encodable)
+    case invalidRequest(request: any SNMRequestConvertible)
+    case invalidURL(url: URL)
+    case invalidStatusCode(statusCode: Int)
+    /// HTTPResponse로 변환 실패
+    case invalidResponse(response: URLResponse)
+    // Status code 300번대
+    // TODO: Redirect는 따로 처리 과정이 필요함
+    case redirection
+    // Status code 400번대
+    case badRequest
+    case unAuthorization
+    case notFound
+    case forbidden
+    case methodNotAllowed
+    case contentTooLarge
+    case urlTooLong
+    case unsupportMediaType
+    // Status code 500번대
+    case serverError
+
+    public var errorDescription: String? {
+        switch self {
+        case .encodingError(let data):
+            "인코딩 에러입니다. \(data)"
+        case .invalidRequest(let request):
+            "잘못된 요청입니다. \(request)"
+        case .invalidURL(let url):
+            "URL이 잘못되었습니다. \(url)"
+        case .invalidResponse(let response):
+            "HTTP 응답이 아닙니다. \(response)"
+        case .invalidStatusCode(let statusCode):
+            "잘못된 status code입니다. \(statusCode)"
+        case .redirection:
+            "리디렉션"
+        case .badRequest:
+            "잘못된 요청입니다."
+        case .unAuthorization:
+            "권한이 없습니다."
+        case .notFound:
+            "요청한 콘텐츠를 찾을 수 없습니다."
+        case .forbidden:
+            "금지된 접근입니다."
+        case .methodNotAllowed:
+            "허용되지 않은 메서드입니다."
+        case .contentTooLarge:
+            "요청 본문이 서버에서 정의한 제한보다 큽니다."
+        case .urlTooLong:
+            "URL이 너무 길어서 요청이 실패하였습니다."
+        case .unsupportMediaType:
+            "요청된 데이터의 미디어 형식이 서버에서 지원되지 않습니다."
+        case .serverError:
+            "서버 에러입니다."
+        }
+    }
+}

--- a/SniffMeet/SniffMeet/Source/SNMNetwork/SNMNetworkResponse.swift
+++ b/SniffMeet/SniffMeet/Source/SNMNetwork/SNMNetworkResponse.swift
@@ -1,0 +1,34 @@
+//
+//  Response.swift
+//  HGDNetwork
+//
+//  Created by 윤지성 on 11/7/24.
+//
+
+import Foundation
+
+public final class SNMNetworkResponse {
+    public let statusCode: Int
+    public let data: Data
+    public let response: HTTPURLResponse?
+    
+    public init(statusCode: Int, data: Data, response: HTTPURLResponse? = nil) {
+        self.statusCode = statusCode
+        self.data = data
+        self.response = response
+    }
+}
+
+extension SNMNetworkResponse: CustomDebugStringConvertible, Equatable {
+    public var description: String {
+        "Status Code: \(statusCode), Data Length: \(data.count)"
+    }
+    
+    public var debugDescription: String { description }
+    
+    public static func == (lhs: SNMNetworkResponse, rhs: SNMNetworkResponse) -> Bool {
+        lhs.statusCode == rhs.statusCode
+        && lhs.data == rhs.data
+        && lhs.response == rhs.response
+    }
+}

--- a/SniffMeet/SniffMeet/Source/SNMNetwork/SNMRequestConvertible.swift
+++ b/SniffMeet/SniffMeet/Source/SNMNetwork/SNMRequestConvertible.swift
@@ -1,0 +1,52 @@
+//
+//  RequestConvertible.swift
+//  HGDNetwork
+//
+//  Created by 윤지성 on 11/7/24.
+//
+
+import Foundation
+
+public protocol SNMRequestConvertible {
+    var endpoint: Endpoint { get }
+    var requestType: SNMRequestType { get }
+}
+
+public extension SNMRequestConvertible {
+    func urlRequest() throws -> URLRequest {
+        var urlRequest = URLRequest(url: endpoint.absoluteURL)
+
+        switch requestType {
+        case .plain:
+            break
+
+        case .header(let header):
+            header.forEach {
+                urlRequest.setValue($0, forHTTPHeaderField: $1)
+            }
+
+        case .jsonEncodableBody(let body):
+            // HTTP Method가 GET이면서 body가 존재하면 invalid로 처리
+            guard !(endpoint.method == .get)
+            else { throw SNMNetworkError.invalidRequest(request: self) }
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            do {
+                let jsonEncoder: JSONEncoder = JSONEncoder()
+                let encodedData = try jsonEncoder.encode(body)
+                urlRequest.httpBody = encodedData
+            } catch {
+                throw SNMNetworkError.encodingError(with: body)
+            }
+        }
+
+        return urlRequest
+    }
+}
+
+public enum SNMRequestType {
+    case plain
+    case header(with: [String: String])
+    /// Content-Type: application/json이 자동으로 적용됩니다.
+    case jsonEncodableBody(with: Encodable)
+    // TODO: MultipartFormData
+}

--- a/SniffMeet/SniffMeet/Source/SNMNetwork/SNMRequestConvertible.swift
+++ b/SniffMeet/SniffMeet/Source/SNMNetwork/SNMRequestConvertible.swift
@@ -31,8 +31,8 @@ public extension SNMRequestConvertible {
             else { throw SNMNetworkError.invalidRequest(request: self) }
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
             do {
-                let jsonEncoder: JSONEncoder = JSONEncoder()
-                let encodedData = try jsonEncoder.encode(body)
+                let anyEncodableBody = AnyEncodable(body)
+                let encodedData = try anyEncodableBody.encode()
                 urlRequest.httpBody = encodedData
             } catch {
                 throw SNMNetworkError.encodingError(with: body)


### PR DESCRIPTION
### 🔖  Issue Number

close #13

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 

설계했던 NW 구조에 따라 구현을 진행했습니다. 

![image](https://github.com/user-attachments/assets/8f92f7f1-ad81-4ca4-aa67-63df8c618106)

- SNMRequestConvertible, SNMResponse 인터페이스
``` swift 
public protocol SNMRequestConvertible {
    var endpoint: Endpoint { get }
    var requestType: SNMRequestType { get }
}
```

SNMRequestConvertible의 extension을 통해 urlRequest로 변환하는 메서드를 선언해 실제 NetworkProviderd에서 URLSession 작업이 가능하도록 했습니다. 
``` swift 
public extension SNMRequestConvertible {
    func urlRequest() throws -> URLRequest {
        // 중략,,,
    }
```

- 사용 예시 
``` swift 
enum MockRequest {
    case getUser(id: String)
    case postUser(user: User)
    case deleteUser(id: Int)
    case putUser(user: User)
}

extension MockRequest: SNMRequestConvertible {
    var endpoint: HGDNetwork.Endpoint {
        let baseURL = URL(string: "https://666329d362966e20ef0bb8de.mockapi.io")!
        var endpoint: Endpoint
        switch self {
        case .getUser(let id):
            endpoint = Endpoint(baseURL: baseURL, path: "user", method: .get)
            endpoint.query = ["id" : "\(id)"]
        case .postUser:
            endpoint = Endpoint(baseURL: baseURL, path: "user", method: .post)
        case .deleteUser(let id):
            endpoint = Endpoint(baseURL: baseURL, path: "user", method: .delete)
        case .putUser(let user):
            endpoint = Endpoint(baseURL: baseURL, path: "user", method: .put)
        }
        return endpoint
    }
    
    var requestType: SNMRequestType {
        switch self {
        case .getUser(let id): .plain
        case .fetchUser: .plain
        case .postUser(let user): .jsonEncodableBody(with: user)
        case .deleteUser(let id): .header(with: ["Authorization": "Bearer HGDMBINPC"])
        case .putUser(let user): .header(with: ["Content-Type": "application/json"])
        }
    }
}
```

- NetworkProvider, SNMNetworkProvider 구현 
RequestConvertible를 파라미터로 받는 객체입니다. 
request를 처리하는 과정에서 Error가 발생하면 SNMError로 무조건 매핑해 던집니다. 

``` swift 
protocol NetworkProvider {
    func request(with: any SNMRequestConvertible) async throws -> SNMNetworkResponse
}
```

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- SNMNetworkError 관련 

편의를 위해 특정 HTTP statusCode와 관련된 에러 일부를 매핑해 내려주는 방식으로 구현을 진행했는데요.
에러가 많아서 다 컨트롤할 수 없거니와,,, 네트워크 모듈단에서 statusCode 에러까지 일일이 처리해주는 게 과한 것 같다는 생각이 들었습니다. 추후 개선할 예정입니다.

``` swift 
public enum SNMNetworkError: LocalizedError {
    // SNMNetwork Error
    case encodingError(with: any Encodable)
    case invalidRequest(request: any SNMRequestConvertible)
    case invalidURL(url: URL)
    case invalidStatusCode(statusCode: Int)
    /// HTTPResponse로 변환 실패
    case invalidResponse(response: URLResponse)
    // Status code 300번대
    // TODO: Redirect는 따로 처리 과정이 필요함
    case redirection
    // Status code 400번대
    case badRequest
    case unAuthorization
    case notFound
    case forbidden
    case methodNotAllowed
    case contentTooLarge
    case urlTooLong
    case unsupportMediaType
    // Status code 500번대
    case serverError
}

```
- public 키워드 관련
추후 모듈화 진행을 위해 모듈화 대상 객체에 public 키워드를 붙였습니다. 
- requestType (header+body 함께 보내는 타입), multipartformdata 도 주말에 추가해두겠습니다...