### PR TITLE
[feat] UIControl + Publisher 구현

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */; };
 		FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A03382CD8CF460047B7ED /* AppDelegate.swift */; };
 		FD3A03432CD8CF460047B7ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */; };
+		FD5134172CEB738D002E76F3 /* UIControl + Publisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5134162CEB7388002E76F3 /* UIControl + Publisher.swift */; };
 		FD69B1B32CE3BC76009D71DC /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1B22CE3BC68009D71DC /* KeychainManager.swift */; };
 		FD69B1B52CE3BC7E009D71DC /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1B42CE3BC79009D71DC /* UserDefaultsManager.swift */; };
 		FD69B1C32CE3BCE4009D71DC /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1B42CE3BC79009D71DC /* UserDefaultsManager.swift */; };
@@ -136,6 +137,7 @@
 		FD3A033A2CD8CF460047B7ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FD3A033B2CD8CF460047B7ED /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		FD5134162CEB7388002E76F3 /* UIControl + Publisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl + Publisher.swift"; sourceTree = "<group>"; };
 		FD69B1B22CE3BC68009D71DC /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		FD69B1B42CE3BC79009D71DC /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		FD69B1BA2CE3BCDC009D71DC /* SNMPersistenceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SNMPersistenceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -248,6 +250,7 @@
 		A2C844CF2CDBE1CB007F2970 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				FD5134162CEB7388002E76F3 /* UIControl + Publisher.swift */,
 				FDEAEA792CE3148C005890FA /* BaseView.swift */,
 				FDEAEA7B2CE314A3005890FA /* BaseViewController.swift */,
 				FDBFA9B02CE1FDED00AA9220 /* LayoutConstant.swift */,
@@ -1261,6 +1264,7 @@
 				320043762CDCA18E00D08B6D /* (null) in Sources */,
 				FDCD02CF2CE917D800B627D8 /* MockRequest.swift in Sources */,
 				A2F825DD2CDFBEB4000C5419 /* ProfileCardView.swift in Sources */,
+				FD5134172CEB738D002E76F3 /* UIControl + Publisher.swift in Sources */,
 				A2C328882CE2481900D255AB /* HomeModuleBuilder.swift in Sources */,
 				995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */,
 				3200441C2CE48C5C00D08B6D /* MPCAdvertiser.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Common/UIControl + Publisher.swift
+++ b/SniffMeet/SniffMeet/Source/Common/UIControl + Publisher.swift
@@ -15,7 +15,7 @@ extension UIControl {
 }
 
 struct UIControlEventPublisher: Publisher {
-    typealias Output = UIControl
+    typealias Output = Void
     typealias Failure = Never
     private let control: UIControl
     private let event: UIControl.Event
@@ -36,7 +36,7 @@ struct UIControlEventPublisher: Publisher {
 }
 
 final class UIControlEventSubscription<S>: Subscription where S: Subscriber,
-                                                              S.Input == UIControl,
+                                                              S.Input == Void,
                                                               S.Failure == Never {
     private weak var control: UIControl?
     private var subscriber: S?
@@ -53,7 +53,6 @@ final class UIControlEventSubscription<S>: Subscription where S: Subscriber,
         control?.removeTarget(self, action: #selector(processControlAction), for: .allEvents)
     }
     @objc func processControlAction() {
-        guard let control else { return }
-        _ = subscriber?.receive(control)
+        _ = subscriber?.receive(())
     }
 }

--- a/SniffMeet/SniffMeet/Source/Common/UIControl + Publisher.swift
+++ b/SniffMeet/SniffMeet/Source/Common/UIControl + Publisher.swift
@@ -1,0 +1,59 @@
+//
+//  UIControl + Publisher.swift
+//  SniffMeet
+//
+//  Created by sole on 11/18/24.
+//
+
+import Combine
+import UIKit
+
+extension UIControl {
+    func publisher(event: UIControl.Event) -> UIControlEventPublisher {
+        UIControlEventPublisher(control: self, event: event)
+    }
+}
+
+struct UIControlEventPublisher: Publisher {
+    typealias Output = UIControl
+    typealias Failure = Never
+    private let control: UIControl
+    private let event: UIControl.Event
+
+    init(control: UIControl, event: UIControl.Event) {
+        self.control = control
+        self.event = event
+    }
+
+    func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
+        let subscription: UIControlEventSubscription = UIControlEventSubscription(
+            subscriber: subscriber,
+            control: control,
+            event: event
+        )
+        subscriber.receive(subscription: subscription)
+    }
+}
+
+final class UIControlEventSubscription<S>: Subscription where S: Subscriber,
+                                                              S.Input == UIControl,
+                                                              S.Failure == Never {
+    private weak var control: UIControl?
+    private var subscriber: S?
+
+    init(subscriber: S? = nil, control: UIControl, event: UIControl.Event) {
+        self.subscriber = subscriber
+        self.control = control
+        control.addTarget(self, action: #selector(processControlAction), for: event)
+    }
+
+    func request(_ demand: Subscribers.Demand) {}
+    func cancel() {
+        subscriber = nil
+        control?.removeTarget(self, action: #selector(processControlAction), for: .allEvents)
+    }
+    @objc func processControlAction() {
+        guard let control else { return }
+        _ = subscriber?.receive(control)
+    }
+}


### PR DESCRIPTION
### 🔖  Issue Number

close #59 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.

- UIControlEventPublisher, UIControlEventSubscription 구현했습니다. 
- UIControl + Publisher를 구현했습니다. 

아래와 같이 사용할 수 있는 익스텐션입니다. 
``` swift 
editButton.publisher(event: .touchUpInside) 
					.sink { // ,,, 중략 }
```
UIButton 외에도 UIControl 타입 친구들은 모두 접근할 수 있습니다