### PR TITLE
[design] 메이트 요청시 교환하는 프로필 카드 뷰

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		320044772CEB4E1E00D08B6D /* RequestWalk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320044762CEB4E0F00D08B6D /* RequestWalk.swift */; };
 		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
 		995D94622CE598FD005A47BF /* NIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94612CE598F0005A47BF /* NIManager.swift */; };
+		995D94A82CECEF91005A47BF /* RequestMateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94A72CECEF91005A47BF /* RequestMateViewController.swift */; };
 		99FA4E792CE0FBBF00553C2E /* ProfileInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */; };
 		A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21435F62CE20D2500564A4D /* TabBarController.swift */; };
 		A288A63D2CDC595000D11C34 /* (null) in Resources */ = {isa = PBXBuildFile; };
@@ -136,6 +137,7 @@
 		320044762CEB4E0F00D08B6D /* RequestWalk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestWalk.swift; sourceTree = "<group>"; };
 		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
 		995D94612CE598F0005A47BF /* NIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIManager.swift; sourceTree = "<group>"; };
+		995D94A72CECEF91005A47BF /* RequestMateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMateViewController.swift; sourceTree = "<group>"; };
 		99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputViewController.swift; sourceTree = "<group>"; };
 		A21435F62CE20D2500564A4D /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		A2C328852CE245AC00D255AB /* TabBarModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarModuleBuilder.swift; sourceTree = "<group>"; };
@@ -989,6 +991,7 @@
 		FDA491872CDA7C3000A36FB0 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				995D94A72CECEF91005A47BF /* RequestMateViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1280,6 +1283,7 @@
 				A2C844D12CDBE1E5007F2970 /* (null) in Sources */,
 				3200444E2CE595EA00D08B6D /* ProfileCreatePresenter.swift in Sources */,
 				FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */,
+				995D94A82CECEF91005A47BF /* RequestMateViewController.swift in Sources */,
 				FD3A03432CD8CF460047B7ED /* SceneDelegate.swift in Sources */,
 				99FA4E792CE0FBBF00553C2E /* ProfileInputViewController.swift in Sources */,
 				FDA04AA92CE91DF8002605AC /* Data + append.swift in Sources */,

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
 		995D94622CE598FD005A47BF /* NIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94612CE598F0005A47BF /* NIManager.swift */; };
 		995D94A82CECEF91005A47BF /* RequestMateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94A72CECEF91005A47BF /* RequestMateViewController.swift */; };
+		995D94AA2CECF8DD005A47BF /* RequestMateInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94A92CECF8C4005A47BF /* RequestMateInteractor.swift */; };
+		995D94AC2CECFA30005A47BF /* RequestMatePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94AB2CECFA24005A47BF /* RequestMatePresenter.swift */; };
+		995D94AE2CED00A4005A47BF /* RequestMateRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94AD2CED0093005A47BF /* RequestMateRouter.swift */; };
 		99FA4E792CE0FBBF00553C2E /* ProfileInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */; };
 		A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21435F62CE20D2500564A4D /* TabBarController.swift */; };
 		A288A63D2CDC595000D11C34 /* (null) in Resources */ = {isa = PBXBuildFile; };
@@ -138,6 +141,9 @@
 		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
 		995D94612CE598F0005A47BF /* NIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIManager.swift; sourceTree = "<group>"; };
 		995D94A72CECEF91005A47BF /* RequestMateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMateViewController.swift; sourceTree = "<group>"; };
+		995D94A92CECF8C4005A47BF /* RequestMateInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMateInteractor.swift; sourceTree = "<group>"; };
+		995D94AB2CECFA24005A47BF /* RequestMatePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMatePresenter.swift; sourceTree = "<group>"; };
+		995D94AD2CED0093005A47BF /* RequestMateRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMateRouter.swift; sourceTree = "<group>"; };
 		99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputViewController.swift; sourceTree = "<group>"; };
 		A21435F62CE20D2500564A4D /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		A2C328852CE245AC00D255AB /* TabBarModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarModuleBuilder.swift; sourceTree = "<group>"; };
@@ -999,6 +1005,7 @@
 		FDA491882CDA7C3000A36FB0 /* Interactor */ = {
 			isa = PBXGroup;
 			children = (
+				995D94A92CECF8C4005A47BF /* RequestMateInteractor.swift */,
 			);
 			path = Interactor;
 			sourceTree = "<group>";
@@ -1006,6 +1013,7 @@
 		FDA491892CDA7C3000A36FB0 /* Presenter */ = {
 			isa = PBXGroup;
 			children = (
+				995D94AB2CECFA24005A47BF /* RequestMatePresenter.swift */,
 			);
 			path = Presenter;
 			sourceTree = "<group>";
@@ -1020,6 +1028,7 @@
 		FDA4918B2CDA7C3000A36FB0 /* Router */ = {
 			isa = PBXGroup;
 			children = (
+				995D94AD2CED0093005A47BF /* RequestMateRouter.swift */,
 			);
 			path = Router;
 			sourceTree = "<group>";
@@ -1303,6 +1312,7 @@
 				FD5134232CEC2BDE002E76F3 /* Routable.swift in Sources */,
 				FD0634282CE596BD003C9D6B /* SNMRequestConvertible.swift in Sources */,
 				320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */,
+				995D94AC2CECFA30005A47BF /* RequestMatePresenter.swift in Sources */,
 				FD0634262CE596B5003C9D6B /* Endpoint.swift in Sources */,
 				320044502CE595F700D08B6D /* ProfileInputPresenter.swift in Sources */,
 				FDE14A522CE8D338001F7A9D /* SNMRequestType.swift in Sources */,
@@ -1317,8 +1327,10 @@
 				320043932CDF3D7F00D08B6D /* KeywordView.swift in Sources */,
 				320044772CEB4E1E00D08B6D /* RequestWalk.swift in Sources */,
 				FDE14A502CE8D2FB001F7A9D /* URLRequest + append.swift in Sources */,
+				995D94AE2CED00A4005A47BF /* RequestMateRouter.swift in Sources */,
 				FD06342C2CE5984D003C9D6B /* SNMNetworkResponse.swift in Sources */,
 				3200445E2CE5CA1B00D08B6D /* SaveInfoUseCase.swift in Sources */,
+				995D94AA2CECF8DD005A47BF /* RequestMateInteractor.swift in Sources */,
 				FD51341B2CEB7AE8002E76F3 /* HomePresenter.swift in Sources */,
 				320043942CDF3D7F00D08B6D /* PrimaryButton.swift in Sources */,
 				FDCD02D12CE917E600B627D8 /* MockURLProtocol.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Common/LayoutConstant.swift
+++ b/SniffMeet/SniffMeet/Source/Common/LayoutConstant.swift
@@ -12,7 +12,8 @@ enum LayoutConstant {
 
     static let horizontalPadding: CGFloat = 24
 
-    static let smallVerticalPadding: CGFloat = 8
+    static let xsmallVerticalPadding: CGFloat = 8
+    static let smallVerticalPadding: CGFloat = 12
     static let regularVerticalPadding: CGFloat = 16
     static let mediumVerticalPadding: CGFloat = 24
     static let largeVerticalPadding: CGFloat = 30

--- a/SniffMeet/SniffMeet/Source/Common/SNMFont.swift
+++ b/SniffMeet/SniffMeet/Source/Common/SNMFont.swift
@@ -24,6 +24,8 @@ enum SNMFont {
     static let subheadline: UIFont = UIFont.systemFont(ofSize: 14, weight: .regular)
     /// size: 16, weight: semibold
     static let callout: UIFont = UIFont.systemFont(ofSize: 16, weight: .semibold)
+    /// size: 16, weight: bold
+    static let callout2: UIFont = UIFont.systemFont(ofSize: 16, weight: .bold)
     /// size: 12, weight: regular
     static let caption: UIFont = UIFont.systemFont(ofSize: 12, weight: .regular)
 }

--- a/SniffMeet/SniffMeet/Source/Entity/Dog.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/Dog.swift
@@ -36,3 +36,9 @@ struct Dog: Codable {
     let nickname: String
     let profileImage: Data?
 }
+
+struct DogProfileInfo {
+    let name: String
+    let keywords: [Keyword]
+    let profileImage: Data?
+}

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/Interactor/RequestMateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/Interactor/RequestMateInteractor.swift
@@ -1,0 +1,18 @@
+//
+//  RequestMateInteractor.swift
+//  SniffMeet
+//
+//  Created by 배현진 on 11/20/24.
+//
+
+protocol RequestMateInteractable: AnyObject {
+    func fetchDogProfile()
+}
+
+final class RequestMateInteractor: RequestMateInteractable {
+    weak var presenter: RequestMatePresentable?
+
+    func fetchDogProfile() {
+        /// 프로필 데이터 가져오고  presenter의 didFetchDogProfile 호출.
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/Presenter/RequestMatePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/Presenter/RequestMatePresenter.swift
@@ -1,0 +1,25 @@
+//
+//  RequestMatePresenter.swift
+//  SniffMeet
+//
+//  Created by 배현진 on 11/20/24.
+//
+
+protocol RequestMatePresentable: AnyObject {
+    func didFetchDogProfile(_ dogProfile: DogProfileInfo)
+    func viewDidLoad()
+}
+
+final class RequestMatePresenter: RequestMatePresentable {
+    weak var view: RequestMateViewable?
+    var interactor: RequestMateInteractable?
+    var router: RequestMateRoutable?
+
+    func viewDidLoad() {
+        interactor?.fetchDogProfile()
+    }
+
+    func didFetchDogProfile(_ dogProfile: DogProfileInfo) {
+        view?.updateView(with: dogProfile)
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/Router/RequestMateRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/Router/RequestMateRouter.swift
@@ -1,0 +1,29 @@
+//
+//  RequestMateRouter.swift
+//  SniffMeet
+//
+//  Created by 배현진 on 11/20/24.
+//
+
+import UIKit
+
+protocol RequestMateRoutable: AnyObject {
+    static func createRequestMateModule() -> UIViewController
+}
+
+final class RequestMateRouter: RequestMateRoutable {
+    static func createRequestMateModule() -> UIViewController {
+        let view = RequestMateViewController()
+        let presenter = RequestMatePresenter()
+        let interactor = RequestMateInteractor()
+        let router = RequestMateRouter()
+        
+        view.presenter = presenter
+        presenter.view = view
+        presenter.interactor = interactor
+        presenter.router = router
+        interactor.presenter = presenter
+
+        return view
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/Router/RequestMateRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/Router/RequestMateRouter.swift
@@ -8,16 +8,28 @@
 import UIKit
 
 protocol RequestMateRoutable: AnyObject {
+    func dismissView(view: any RequestMateViewable)
+}
+
+protocol RequestMateBuildable {
     static func createRequestMateModule() -> UIViewController
 }
 
 final class RequestMateRouter: RequestMateRoutable {
+    func dismissView(view: any RequestMateViewable) {
+        if let view = view as? UIViewController {
+            view.dismiss(animated: true)
+        }
+    }
+}
+
+extension RequestMateRouter: RequestMateBuildable {
     static func createRequestMateModule() -> UIViewController {
         let view = RequestMateViewController()
         let presenter = RequestMatePresenter()
         let interactor = RequestMateInteractor()
-        let router = RequestMateRouter()
-        
+        let router: RequestMateRoutable & RequestMateBuildable = RequestMateRouter()
+
         view.presenter = presenter
         presenter.view = view
         presenter.interactor = interactor

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
@@ -7,7 +7,13 @@
 
 import UIKit
 
-final class RequestMateViewController: UIViewController {
+protocol RequestMateViewable: AnyObject {
+    func updateView(with profile: DogProfileInfo)
+}
+
+final class RequestMateViewController: BaseViewController, RequestMateViewable {
+    var presenter: RequestMatePresentable?
+
     private var zStackView = UIView()
     private var profileImageView = UIImageView()
     private var nameLabel = UILabel()
@@ -26,9 +32,10 @@ final class RequestMateViewController: UIViewController {
         configureHierachy()
         configureConstraints()
         bind()
+        presenter?.viewDidLoad()
     }
 
-    func configureAttributes() {
+    override func configureAttributes() {
         profileImageView.image = UIImage(named: "ImagePlaceholder")
         profileImageView.contentMode = .scaleAspectFill
         profileImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -56,7 +63,7 @@ final class RequestMateViewController: UIViewController {
         declineButton = UIButton(configuration: declineConfig)
     }
 
-    func configureHierachy() {
+    override func configureHierachy() {
         for keyword in keywords {
             let keywordView = KeywordView(title: keyword.rawValue)
             keywordStackView.addArrangedSubview(keywordView)
@@ -76,7 +83,7 @@ final class RequestMateViewController: UIViewController {
         }
     }
 
-    func configureConstraints() {
+    override func configureConstraints() {
         let constraints = [
             profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             profileImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
@@ -120,7 +127,16 @@ final class RequestMateViewController: UIViewController {
         ]
         NSLayoutConstraint.activate(constraints)
     }
-    func bind() {}
+    override func bind() {}
+
+    func updateView(with profile: DogProfileInfo) {
+        if let profileImageData = profile.profileImage {
+            let uiImage = UIImage(data: profileImageData)
+            profileImageView.image = uiImage
+        }
+        nameLabel.text = profile.name
+        keywords = profile.keywords
+    }
 }
 
 private extension RequestMateViewController {

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
@@ -1,0 +1,135 @@
+//
+//  RequestMateViewController.swift
+//  SniffMeet
+//
+//  Created by 배현진 on 11/20/24.
+//
+
+import UIKit
+
+final class RequestMateViewController: UIViewController {
+    private var zStackView = UIView()
+    private var profileImageView = UIImageView()
+    private var nameLabel = UILabel()
+    private var keywordStackView = UIStackView()
+    private var declineConfig = UIButton.Configuration.filled()
+    private var declineButton: UIButton = UIButton(type: .system)
+    private var acceptButton = PrimaryButton(title: Context.acceptTitle)
+    private var keywords: [Keyword] = [Keyword.energetic, Keyword.energetic]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .white
+
+        configureAttributes()
+        configureHierachy()
+        configureConstraints()
+        bind()
+    }
+
+    func configureAttributes() {
+        profileImageView.image = UIImage(named: "ImagePlaceholder")
+        profileImageView.contentMode = .scaleAspectFill
+        profileImageView.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.text = "이름"
+        nameLabel.textColor = SNMColor.white
+        nameLabel.font = SNMFont.title1
+        keywordStackView.axis = .horizontal
+        keywordStackView.spacing = Context.keywordsStackViewSpacing
+        keywordStackView.translatesAutoresizingMaskIntoConstraints = false
+        declineConfig.baseBackgroundColor = SNMColor.disabledGray
+        declineConfig.baseForegroundColor = SNMColor.mainNavy
+        declineConfig.cornerStyle = .large
+        declineConfig.contentInsets = NSDirectionalEdgeInsets(
+            top: Context.buttonContentVerticalInsets,
+            leading: Context.buttonContentHorizontalInsets,
+            bottom: Context.buttonContentVerticalInsets,
+            trailing: Context.buttonContentHorizontalInsets
+        )
+        declineConfig.attributedTitle = AttributedString(
+            Context.declineTitle,
+            attributes: AttributeContainer(
+                [.font: SNMFont.callout2]
+            )
+        )
+        declineButton = UIButton(configuration: declineConfig)
+    }
+
+    func configureHierachy() {
+        for keyword in keywords {
+            let keywordView = KeywordView(title: keyword.rawValue)
+            keywordStackView.addArrangedSubview(keywordView)
+        }
+
+        zStackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(zStackView)
+        zStackView.addSubview(profileImageView)
+
+        [profileImageView,
+         nameLabel,
+         keywordStackView,
+         declineButton,
+         acceptButton].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            zStackView.addSubview($0)
+        }
+    }
+
+    func configureConstraints() {
+        let constraints = [
+            profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            profileImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            nameLabel.bottomAnchor.constraint(
+                equalTo: keywordStackView.topAnchor,
+                constant: -LayoutConstant.smallVerticalPadding
+            ),
+            nameLabel.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: LayoutConstant.horizontalPadding
+            ),
+            keywordStackView.bottomAnchor.constraint(
+                equalTo: declineButton.topAnchor,
+                constant: -LayoutConstant.mediumVerticalPadding
+            ),
+            keywordStackView.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: LayoutConstant.horizontalPadding
+            ),
+            declineButton.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -LayoutConstant.xlargeVerticalPadding
+            ),
+            declineButton.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: LayoutConstant.horizontalPadding
+            ),
+            acceptButton.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -LayoutConstant.xlargeVerticalPadding
+            ),
+            acceptButton.leadingAnchor.constraint(
+                equalTo: declineButton.trailingAnchor,
+                constant: LayoutConstant.smallVerticalPadding
+            ),
+            acceptButton.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -LayoutConstant.horizontalPadding
+            ),
+            acceptButton.widthAnchor.constraint(equalTo: declineButton.widthAnchor, multiplier: Context.multiplier)
+        ]
+        NSLayoutConstraint.activate(constraints)
+    }
+    func bind() {}
+}
+
+private extension RequestMateViewController {
+    enum Context {
+        static let acceptTitle: String = "요청 수락"
+        static let declineTitle: String = "요청 거절"
+        static let keywordsStackViewSpacing: CGFloat = 8
+        static let buttonContentHorizontalInsets: CGFloat = 16
+        static let buttonContentVerticalInsets: CGFloat = 20
+        static let multiplier: CGFloat = 2.5
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
@@ -21,17 +21,11 @@ final class RequestMateViewController: BaseViewController, RequestMateViewable {
     private var declineConfig = UIButton.Configuration.filled()
     private var declineButton: UIButton = UIButton(type: .system)
     private var acceptButton = PrimaryButton(title: Context.acceptTitle)
-    private var keywords: [Keyword] = [Keyword.energetic, Keyword.energetic]
+    private var keywords: [Keyword] = [.energetic, .independent]
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .white
-
-        configureAttributes()
-        configureHierachy()
-        configureConstraints()
-        bind()
         presenter?.viewDidLoad()
     }
 


### PR DESCRIPTION
### 🔖  Issue Number

close https://github.com/boostcampwm-2024/iOS03-SniffMeet/issues/69

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] ViewController에 코드 베이스 뷰 구현 작업
- [x] 화면 꽉 찬 이미지, 그 위에 이름, 키워드들, 수락/거절 버튼 표시
- [x] SNMFont, LayoutConstant 공통 상수 추가
- [x] VIPER 패턴 따르도록 미리 구조화하기

<img width="240" src="https://github.com/user-attachments/assets/7366a66e-b885-408f-9098-6a11e09b4d25">

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1 프로필 카드에서 보여줄 정보
프로필 카드에서 현재 보여주는 정보는 이미지, 이름, 키워드가 끝입니다.
나이, 크기의 정보도 함께 공유해주는 것이 더 좋을까요? (추가로, 정보 입력 부분에 없긴 했는데 성별.. 필요할까요? 중성화 여부 등등..)
현재로도 충분한것같기도 하고, 메이트를 맺기 전 보여주는 정보로는 조금 부족한 것 같기도 합니다.
우선은 기존 기획대로 진행하고 나중에 추가해도 될 것 같기도 합니다. 어떻게 생각하시나요? 

- 특이 사항 2 데이터 표시
현재, 데이터를 전송받는 부분을 제외하고 뷰와 VIPER 구조만 적용되어 있기 때문에 임시로 넣은 기본값들로 화면이 표시됩니다.
서로에게 데이터 전달 받으면, 해당 데이터 보일 수 있도록 수정하겠습니다.
이름, 키워드, 이미지만 필요하기 때문에 DogProfileInfo Entity를 추가해 이용하도록 했는데,
불필요한 변수값이 있어도, 무시하고 기존 Entity 이용하는것이 좋을까요?

- 특이 사항 3 디자인
요청 거절 버튼을 피그마와 살짝 다르게 만들었습니다.
다른 요소에서는 적용된 적 없는 회색이라 기존 disabled 색상 이용했습니다.
이전에도 그랬던 것처럼 disabled 색상이 적용되니 흰 글씨가 잘 안보여 글씨 색상도 변경했습니다.

- 특이 사항 4 VIPER
열심히 VIPER 구조 학습하고 적용해봤는데, 아직 기본 구조만 구현해서 괜찮게 구현했다고 생각합니다..!
확인해봐주시고 부족한 부분 피드백 부탁드립니다. 🙇‍♀️

### 👻 레퍼런스

