### PR TITLE
[feat] Supabase database 레이어 추가

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -53,7 +53,9 @@
 		995D94AC2CECFA30005A47BF /* RequestMatePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94AB2CECFA24005A47BF /* RequestMatePresenter.swift */; };
 		995D94AE2CED00A4005A47BF /* RequestMateRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94AD2CED0093005A47BF /* RequestMateRouter.swift */; };
 		99FA4E792CE0FBBF00553C2E /* ProfileInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */; };
-		A20E71502CEC595C00272B25 /* SupabaseAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E714F2CEC595C00272B25 /* SupabaseAuthError.swift */; };
+		A202A1152CEDD50700B98203 /* SupabaseDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A202A1142CEDD50700B98203 /* SupabaseDatabaseManager.swift */; };
+		A202A1172CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A202A1162CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift */; };
+		A20E71502CEC595C00272B25 /* SupabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E714F2CEC595C00272B25 /* SupabaseError.swift */; };
 		A20E71522CEC5FE900272B25 /* SupabaseUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E71512CEC5FE900272B25 /* SupabaseUserResponse.swift */; };
 		A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21435F62CE20D2500564A4D /* TabBarController.swift */; };
 		A24082612CEB244C009109A0 /* SupabaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24082602CEB244C009109A0 /* SupabaseConfig.swift */; };
@@ -177,7 +179,9 @@
 		995D94AB2CECFA24005A47BF /* RequestMatePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMatePresenter.swift; sourceTree = "<group>"; };
 		995D94AD2CED0093005A47BF /* RequestMateRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMateRouter.swift; sourceTree = "<group>"; };
 		99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputViewController.swift; sourceTree = "<group>"; };
-		A20E714F2CEC595C00272B25 /* SupabaseAuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseAuthError.swift; sourceTree = "<group>"; };
+		A202A1142CEDD50700B98203 /* SupabaseDatabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseDatabaseManager.swift; sourceTree = "<group>"; };
+		A202A1162CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseDatabaseRequest.swift; sourceTree = "<group>"; };
+		A20E714F2CEC595C00272B25 /* SupabaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseError.swift; sourceTree = "<group>"; };
 		A20E71512CEC5FE900272B25 /* SupabaseUserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseUserResponse.swift; sourceTree = "<group>"; };
 		A21435F62CE20D2500564A4D /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		A24082602CEB244C009109A0 /* SupabaseConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseConfig.swift; sourceTree = "<group>"; };
@@ -363,6 +367,15 @@
 			path = NI;
 			sourceTree = "<group>";
 		};
+		A202A1132CEDD4CD00B98203 /* Database */ = {
+			isa = PBXGroup;
+			children = (
+				A202A1142CEDD50700B98203 /* SupabaseDatabaseManager.swift */,
+				A202A1162CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift */,
+			);
+			path = Database;
+			sourceTree = "<group>";
+		};
 		A21435F52CE20CF600564A4D /* Tab */ = {
 			isa = PBXGroup;
 			children = (
@@ -377,7 +390,9 @@
 			isa = PBXGroup;
 			children = (
 				A24082602CEB244C009109A0 /* SupabaseConfig.swift */,
+				A20E714F2CEC595C00272B25 /* SupabaseError.swift */,
 				A24082652CEB2475009109A0 /* Auth */,
+				A202A1132CEDD4CD00B98203 /* Database */,
 			);
 			path = Supabase;
 			sourceTree = "<group>";
@@ -388,7 +403,6 @@
 				A24082632CEB2470009109A0 /* SupabaseAuthManager.swift */,
 				A25BE4592CEC2BA300886763 /* SessionManager.swift */,
 				A240826F2CEB27DE009109A0 /* SupabaseRequest.swift */,
-				A20E714F2CEC595C00272B25 /* SupabaseAuthError.swift */,
 				A25BE4532CEBB60200886763 /* Entity */,
 			);
 			path = Auth;
@@ -1433,6 +1447,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A202A1152CEDD50700B98203 /* SupabaseDatabaseManager.swift in Sources */,
 				995D94622CE598FD005A47BF /* NIManager.swift in Sources */,
 				FDBFA9A12CE1E51500AA9220 /* SNMColor.swift in Sources */,
 				A24082702CEB27DE009109A0 /* SupabaseRequest.swift in Sources */,
@@ -1441,6 +1456,7 @@
 				320044922CED78D200D08B6D /* RespondWalkPresenter.swift in Sources */,
 				FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */,
 				995D94A82CECEF91005A47BF /* RequestMateViewController.swift in Sources */,
+				A202A1172CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift in Sources */,
 				FD3A03432CD8CF460047B7ED /* SceneDelegate.swift in Sources */,
 				99FA4E792CE0FBBF00553C2E /* ProfileInputViewController.swift in Sources */,
 				3200448D2CEC878300D08B6D /* RespondWalkViewController.swift in Sources */,
@@ -1451,7 +1467,7 @@
 				FDEAEA7C2CE314A7005890FA /* BaseViewController.swift in Sources */,
 				A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */,
 				320043762CDCA18E00D08B6D /* (null) in Sources */,
-				A20E71502CEC595C00272B25 /* SupabaseAuthError.swift in Sources */,
+				A20E71502CEC595C00272B25 /* SupabaseError.swift in Sources */,
 				FDCD02CF2CE917D800B627D8 /* MockRequest.swift in Sources */,
 				A2F825DD2CDFBEB4000C5419 /* ProfileCardView.swift in Sources */,
 				FD51341F2CEB7AFE002E76F3 /* LoadDogInfoUseCase.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Supabase/Auth/SupabaseAuthManager.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Auth/SupabaseAuthManager.swift
@@ -66,7 +66,7 @@ final class SupabaseAuthManager: AuthManager {
     func refreshSession() async throws { // 세션 갱신
         // 세션에서 토큰 가져옴
         guard let refreshToken = SessionManager.shared.session?.refreshToken else {
-            throw SupabaseAuthError.sessionNotExist
+            throw SupabaseError.sessionNotExist
         }
         // 가져온 토큰으로 갱신 요청
         let response = try await networkProvider.request(
@@ -97,7 +97,7 @@ final class SupabaseAuthManager: AuthManager {
     }
 
     private func saveSession(for session: SupabaseSession?) throws {
-        guard let session else { throw SupabaseAuthError.sessionNotExist }
+        guard let session else { throw SupabaseError.sessionNotExist }
         SessionManager.shared.session = session
         try KeychainManager.shared.set(value: session.accessToken, forKey: "accessToken")
         try KeychainManager.shared.set(value: session.refreshToken, forKey: "refreshToken")

--- a/SniffMeet/SniffMeet/Source/Supabase/Auth/SupabaseRequest.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Auth/SupabaseRequest.swift
@@ -28,7 +28,7 @@ extension SupabaseRequest: SNMRequestConvertible {
                 path: "auth/v1/token",
                 method: .post,
                 query: [
-                    "grant_type": "refreshToken"
+                    "grant_type": "refresh_token"
                 ]
             )
         case .refreshUser:
@@ -53,9 +53,10 @@ extension SupabaseRequest: SNMRequestConvertible {
                 body: Data("{}".utf8)
             )
         case .refreshToken(let refreshToken):
-            return SNMRequestType.compositeJSONEncodable(
+            header["Authorization"] = nil
+            return SNMRequestType.compositePlain(
                 header: header,
-                body: SupabaseTokenRequest(refreshToken: refreshToken)
+                body: Data("{ \"refresh_token\": \"\(refreshToken)\" }".utf8)
             )
         case .refreshUser(let accessToken):
             header["Authorization"] = "Bearer \(accessToken)"

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
@@ -1,0 +1,68 @@
+//
+//  SupabaseDatabaseManager.swift
+//  SniffMeet
+//
+//  Created by Kelly Chui on 11/20/24.
+//
+
+import Combine
+import Foundation
+
+protocol RemoteDatabaseManager {
+    static var shared: RemoteDatabaseManager { get }
+    func fetchValue(from table: String) async throws -> Data
+    func insertValue(into table: String, with value: Data) async throws
+    // func updateValue()
+}
+
+enum DatabaseState: String, CaseIterable {
+    case fetchValue
+    case insertValue
+}
+
+final class SupabaseDatabaseManager: RemoteDatabaseManager {
+    var storageStateSubject: PassthroughSubject<DatabaseState, Never>
+    private let networkProvider: SNMNetworkProvider
+    private let decoder: JSONDecoder
+    private var cancellables: Set<AnyCancellable>
+    static let shared: RemoteDatabaseManager = SupabaseDatabaseManager()
+
+    private init() {
+        storageStateSubject = PassthroughSubject<DatabaseState, Never>()
+        networkProvider = SNMNetworkProvider()
+        decoder = JSONDecoder()
+        cancellables = Set<AnyCancellable>()
+    }
+
+    func fetchValue(from table: String) async throws -> Data {
+        if SessionManager.shared.isExpired {
+            try await SupabaseAuthManager.shared.refreshSession()
+        }
+        guard let session = SessionManager.shared.session else {
+            throw SupabaseError.sessionNotExist
+        }
+        let response = try await networkProvider.request(
+            with: SupabaseDatabaseRequest.fetchValue(
+                table: table,
+                accessToken: session.accessToken
+            )
+        )
+        return response.data
+    }
+
+    func insertValue(into table: String, with value: Data) async throws {
+        if SessionManager.shared.isExpired {
+            try await SupabaseAuthManager.shared.refreshSession()
+        }
+        guard let session = SessionManager.shared.session else {
+            throw SupabaseError.sessionNotExist
+        }
+        _ = try await networkProvider.request(
+            with: SupabaseDatabaseRequest.insertValue(
+                table: table,
+                accessToken: session.accessToken,
+                data: value
+            )
+        )
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
@@ -9,13 +9,12 @@ import Combine
 import Foundation
 
 protocol RemoteDatabaseManager {
-    static var shared: RemoteDatabaseManager { get }
     func fetchData(from table: String) async throws -> Data
     func insertData(into table: String, with data: Data) async throws
     // func updateData()
 }
 
-enum DatabaseState: String, CaseIterable {
+enum DatabaseState {
     case fetchData
     case insertData
 }

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseRequest.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseRequest.swift
@@ -8,22 +8,22 @@
 import Foundation
 
 enum SupabaseDatabaseRequest {
-    case fetchValue(table: String, accessToken: String)
-    case insertValue(table: String, accessToken: String, data: Data)
-    // case updateValue(table: String, accessToken: String)
+    case fetchData(table: String, accessToken: String)
+    case insertData(table: String, accessToken: String, data: Data)
+    // case updateData(table: String, accessToken: String)
 }
 
 extension SupabaseDatabaseRequest: SNMRequestConvertible {
     var endpoint: Endpoint {
         switch self {
-        case .fetchValue(let table, _):
+        case .fetchData(let table, _):
             return Endpoint(
                 baseURL: SupabaseConfig.baseURL,
                 path: "rest/v1/\(table)",
                 method: .get,
                 query: nil
             )
-        case .insertValue(let table, _, _):
+        case .insertData(let table, _, _):
             return Endpoint(
                 baseURL: SupabaseConfig.baseURL,
                 path: "rest/v1/\(table)",
@@ -38,12 +38,12 @@ extension SupabaseDatabaseRequest: SNMRequestConvertible {
             "apikey": SupabaseConfig.apiKey
         ]
         switch self {
-        case .fetchValue(_, let accessToken):
+        case .fetchData(_, let accessToken):
             header["Authorization"] = "Bearer \(accessToken)"
             return SNMRequestType.header(
                 with: header
             )
-        case .insertValue(_, let accessToken, let data):
+        case .insertData(_, let accessToken, let data):
             header["Authorization"] = "Bearer \(accessToken)"
             return SNMRequestType.compositePlain(
                 header: header,

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseRequest.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseRequest.swift
@@ -1,0 +1,54 @@
+//
+//  SupabaseStorageRequest.swift
+//  SniffMeet
+//
+//  Created by Kelly Chui on 11/20/24.
+//
+
+import Foundation
+
+enum SupabaseDatabaseRequest {
+    case fetchValue(table: String, accessToken: String)
+    case insertValue(table: String, accessToken: String, data: Data)
+    // case updateValue(table: String, accessToken: String)
+}
+
+extension SupabaseDatabaseRequest: SNMRequestConvertible {
+    var endpoint: Endpoint {
+        switch self {
+        case .fetchValue(let table, _):
+            return Endpoint(
+                baseURL: SupabaseConfig.baseURL,
+                path: "rest/v1/\(table)",
+                method: .get,
+                query: nil
+            )
+        case .insertValue(let table, _, _):
+            return Endpoint(
+                baseURL: SupabaseConfig.baseURL,
+                path: "rest/v1/\(table)",
+                method: .post,
+                query: nil
+            )
+        }
+    }
+    var requestType: SNMRequestType {
+        var header = [
+            "Content-Type": "application/json",
+            "apikey": SupabaseConfig.apiKey
+        ]
+        switch self {
+        case .fetchValue(_, let accessToken):
+            header["Authorization"] = "Bearer \(accessToken)"
+            return SNMRequestType.header(
+                with: header
+            )
+        case .insertValue(_, let accessToken, let data):
+            header["Authorization"] = "Bearer \(accessToken)"
+            return SNMRequestType.compositePlain(
+                header: header,
+                body: data
+            )
+        }
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Supabase/SupabaseError.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/SupabaseError.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-enum SupabaseAuthError: Error {
+enum SupabaseError: Error {
     case sessionNotExist
 }


### PR DESCRIPTION
### 🔖  Issue Number

close #73 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  Supabase database 레이어 추가
    - [x]  fetch 작업 구현
    - [x]  insert 작업 구현
- [x]  `SupabaseAuthError`를 `SupabaseError`로 변경
    - [x]  Snake case 로 작성되어야 할 리터럴이 Camel case로 작성되어 있던 부분 수정

에러 처리와 관련된 내용은 더 이상 Supabase database와 연관된 내용이 아니라 판단하여 이슈를 따로 분리하겠습니다.

**fetch 작업**
![image](https://github.com/user-attachments/assets/4307aa75-e3ac-489e-a14f-5693f27f812e)


**insert 작업 (추가 레코드 insert 한 상태)**
<img width="682" alt="Screenshot 2024-11-21 at 1 14 55 PM" src="https://github.com/user-attachments/assets/f628e609-95f2-4c18-80f7-a148d39b9ce7">

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 현재 fetch/insert 작업을 할 때 `Data` 타입을 직접 다루고 있습니다.
```swift
protocol RemoteDatabaseManager {
    static var shared: RemoteDatabaseManager { get }
    func fetchValue(from table: String) async throws -> Data
    func insertValue(into table: String, with value: Data) async throws
    // func updateValue()
}
```
- fetch/insert 동작에서 사용할 데이터의 모든 인터페이스 혹은 콘크리트 타입을 예상할 수 없고, 앞으로 생길 `fetchProfile`이나 `InsertProfile`과 같은 작업에서 수행할 것으로 예상하기 때문에 이후에 생길 메소드에서 인코딩/디코딩 작업을 수행하도록 의도했습니다.
- 현재 예외 처리가 깔끔하게 되어있지 않습니다. 이 부분은 Auth와 함께 처리해야할 문제라고 판단하여 따로 이슈를 생성하여 진행하겠습니다. 좋은 의견 있으시면 리뷰에 남겨주시면 감사하겠습니다. 

### 👻 레퍼런스
- [Supabase Docs Database](https://supabase.com/docs/guides/database/overview)