### PR TITLE
[design] 메이트 리스트 뷰 컨트롤러 추가

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		A25BE4582CEBB95C00886763 /* SupabaseRefreshResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BE4572CEBB95C00886763 /* SupabaseRefreshResponse.swift */; };
 		A25BE45A2CEC2BA300886763 /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BE4592CEC2BA300886763 /* SessionManager.swift */; };
 		A288A63D2CDC595000D11C34 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		A2BA1B922CF1E8C60080575A /* MateListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2BA1B912CF1E8C60080575A /* MateListViewController.swift */; };
 		A2C328862CE245AC00D255AB /* TabBarModuleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328852CE245AC00D255AB /* TabBarModuleBuilder.swift */; };
 		A2C328882CE2481900D255AB /* HomeModuleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328872CE2481900D255AB /* HomeModuleBuilder.swift */; };
 		A2C328922CE3BEA000D255AB /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328912CE3BEA000D255AB /* AppRouter.swift */; };
@@ -201,6 +202,7 @@
 		A25BE4552CEBB63A00886763 /* SupabaseUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseUser.swift; sourceTree = "<group>"; };
 		A25BE4572CEBB95C00886763 /* SupabaseRefreshResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseRefreshResponse.swift; sourceTree = "<group>"; };
 		A25BE4592CEC2BA300886763 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
+		A2BA1B912CF1E8C60080575A /* MateListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateListViewController.swift; sourceTree = "<group>"; };
 		A2C328852CE245AC00D255AB /* TabBarModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarModuleBuilder.swift; sourceTree = "<group>"; };
 		A2C328872CE2481900D255AB /* HomeModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModuleBuilder.swift; sourceTree = "<group>"; };
 		A2C328912CE3BEA000D255AB /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
@@ -743,6 +745,7 @@
 		FDA491492CDA074E00A36FB0 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				A2BA1B912CF1E8C60080575A /* MateListViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1568,6 +1571,7 @@
 				FD0634312CE62578003C9D6B /* AnyEncodable.swift in Sources */,
 				3200441A2CE48A3D00D08B6D /* MPCBroswer.swift in Sources */,
 				A25BE4562CEBB63A00886763 /* SupabaseUser.swift in Sources */,
+				A2BA1B922CF1E8C60080575A /* MateListViewController.swift in Sources */,
 				A24082722CEB36B8009109A0 /* SupabaseTokenRequest.swift in Sources */,
 				3200437C2CDCA6F300D08B6D /* (null) in Sources */,
 				3200445A2CE5B3AA00D08B6D /* ProfileCreateInteractor.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
@@ -1,0 +1,130 @@
+//
+//  MateListViewController.swift
+//  SniffMeet
+//
+//  Created by Kelly Chui on 11/21/24.
+//
+
+import Combine
+import UIKit
+
+protocol MateListViewable: AnyObject {
+    // var presenter: (any MateListPresentable)? { get }
+}
+
+final class MateListViewController: BaseViewController, MateListViewable {
+    // var presenter: any MateListPresentable?
+    private let tableView: UITableView = {
+        let tableView = UITableView()
+        return tableView
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override func configureAttributes() {
+        navigationItem.title = Context.title
+        setTableView()
+    }
+
+    override func configureHierachy() {
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    override func configureConstraints() {
+        let constraints = [
+            tableView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor
+            ),
+            tableView.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor
+            ),
+            tableView.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor
+            ),
+            tableView.bottomAnchor.constraint(
+                equalTo: view.bottomAnchor
+            )
+        ]
+        NSLayoutConstraint.activate(constraints)
+    }
+
+    override func bind() {
+//        presenter?.mates
+//            .sink { [weak self] in
+//                self?.updateTableView()
+//            }
+//            .store(in: &cancellables)
+    }
+
+    private func setTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: Identifier.mateCellID)
+        tableView.separatorStyle = .none
+    }
+
+    func updateTableView() {
+        // 네트워크에서 mate를 다 불러오면 호출됩니다.
+        // FIXME: Diffable data source
+        tableView.reloadData()
+    }
+}
+
+extension MateListViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 3 // presenter.mates.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: Identifier.mateCellID, for: indexPath)
+        var content = cell.defaultContentConfiguration()
+        content.image = .app // presenter.setCellImage?
+        content.imageProperties.maximumSize = ItemSize.profileImageSize
+        content.imageProperties.cornerRadius = ItemSize.profileImageCornerRadius
+        content.text = "Mate" // presenter.mates[indexPath].name
+        cell.contentConfiguration = content
+        cell.accessoryView = createAccessoryButton()
+        cell.selectionStyle = .none
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return ItemSize.cellHeight
+    }
+
+    private func createAccessoryButton() -> UIButton {
+        // 공용 뷰 컴포넌트가 아니라서 common에 분리하지 않았습니다.
+        let button = UIButton(type: .roundedRect)
+        button.frame = CGRect(origin: .zero, size: ItemSize.accessoryButtonSize)
+        button.backgroundColor = SNMColor.mainBrown
+        button.setTitle(Context.accessoryButtonLabel, for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = button.frame.height / 2
+        button.clipsToBounds = true
+        return button
+    }
+}
+
+// MARK: - MateListViewController+Context
+
+extension MateListViewController {
+    private enum Context {
+        static let title = "메이트"
+        static let primaryButtonLabel = "메이트 연결하기"
+        static let accessoryButtonLabel = "산책 신청하기"
+    }
+
+    private enum Identifier {
+        static let mateCellID = "mateCellID"
+    }
+
+    private enum ItemSize {
+        static let profileImageSize = CGSize(width: 60, height: 60)
+        static let profileImageCornerRadius: CGFloat = 30
+        static let accessoryButtonSize = CGSize(width: 100, height: 30)
+        static let cellHeight: CGFloat = 70
+    }
+}


### PR DESCRIPTION
### 🔖  Issue Number

close #

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- 메이트 리스트 뷰 컨트롤러 구현
<img src = "https://github.com/user-attachments/assets/258a3111-9816-4baa-9ac5-28b149e96b1f" width = 400>

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 악세서리 버튼은 공용 컴포넌트가 아니여서 분리하지 않았습니다.
    -  악세서리 뷰로 설정하면 `UIButton`의 `Configuration`이 잘 적용되지 않아서 이전 방식으로 구현했습니다.
- 테이블 뷰의 데이터가 뷰 컨트롤러에 `dataSource`라는 이름으로 있습니다. 이 부분이 VIPER에 맞는지 확인해주시면 감사하겠습니다.

