### PR TITLE
[feat] Supabase Storage API 구현 

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -88,6 +88,36 @@
 		FD119F4E2CED87C200BE22BD /* SelectLocationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD119F4D2CED87BC00BE22BD /* SelectLocationPresenter.swift */; };
 		FD119F502CED87E500BE22BD /* SelectLocationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD119F4F2CED87DD00BE22BD /* SelectLocationRouter.swift */; };
 		FD119F522CED881300BE22BD /* SelectLocationModuleBuildable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD119F512CED880A00BE22BD /* SelectLocationModuleBuildable.swift */; };
+		FD331A602CF339B000F39426 /* SupabaseStorageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD331A5F2CF339AA00F39426 /* SupabaseStorageRequest.swift */; };
+		FD331A722CF33C8400F39426 /* SupabaseStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD331A712CF33C7F00F39426 /* SupabaseStorageTests.swift */; };
+		FD331A732CF33CF200F39426 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA04AA42CE91DB7002605AC /* MultipartFormData.swift */; };
+		FD331A742CF33CF200F39426 /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE14A4D2CE8D13E001F7A9D /* HTTPStatusCode.swift */; };
+		FD331A752CF33CF200F39426 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634292CE596C2003C9D6B /* NetworkProvider.swift */; };
+		FD331A762CF33CF200F39426 /* SNMRequestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE14A512CE8D331001F7A9D /* SNMRequestType.swift */; };
+		FD331A772CF33CF200F39426 /* SNMRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634272CE596BA003C9D6B /* SNMRequestConvertible.swift */; };
+		FD331A782CF33CF200F39426 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634252CE596B2003C9D6B /* Endpoint.swift */; };
+		FD331A792CF33CF200F39426 /* SNMNetworkResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD06342B2CE59843003C9D6B /* SNMNetworkResponse.swift */; };
+		FD331A7A2CF33CF200F39426 /* Data + append.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA04AA72CE91DF4002605AC /* Data + append.swift */; };
+		FD331A7B2CF33CF200F39426 /* URLRequest + append.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE14A4F2CE8D2E7001F7A9D /* URLRequest + append.swift */; };
+		FD331A7C2CF33CF200F39426 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634302CE62573003C9D6B /* AnyEncodable.swift */; };
+		FD331A7D2CF33D0500F39426 /* SupabaseStorageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD331A5F2CF339AA00F39426 /* SupabaseStorageRequest.swift */; };
+		FD331A7E2CF33D0500F39426 /* SupabaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24082602CEB244C009109A0 /* SupabaseConfig.swift */; };
+		FD331A7F2CF33D0500F39426 /* SupabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E714F2CEC595C00272B25 /* SupabaseError.swift */; };
+		FD331A802CF33D0500F39426 /* SupabaseAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24082632CEB2470009109A0 /* SupabaseAuthManager.swift */; };
+		FD331A812CF33D0500F39426 /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BE4592CEC2BA300886763 /* SessionManager.swift */; };
+		FD331A822CF33D0500F39426 /* SupabaseRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A240826F2CEB27DE009109A0 /* SupabaseRequest.swift */; };
+		FD331A832CF33D0500F39426 /* SupabaseSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BE4512CEBB5A900886763 /* SupabaseSession.swift */; };
+		FD331A842CF33D0500F39426 /* SupabaseUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BE4552CEBB63A00886763 /* SupabaseUser.swift */; };
+		FD331A852CF33D0500F39426 /* SupabaseSessionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24082662CEB2539009109A0 /* SupabaseSessionResponse.swift */; };
+		FD331A862CF33D0500F39426 /* SupabaseUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E71512CEC5FE900272B25 /* SupabaseUserResponse.swift */; };
+		FD331A872CF33D0500F39426 /* SupabaseRefreshResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BE4572CEBB95C00886763 /* SupabaseRefreshResponse.swift */; };
+		FD331A882CF33D0500F39426 /* SupabaseTokenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24082712CEB36B8009109A0 /* SupabaseTokenRequest.swift */; };
+		FD331A892CF33D0500F39426 /* SupabaseDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A202A1142CEDD50700B98203 /* SupabaseDatabaseManager.swift */; };
+		FD331A8A2CF33D0500F39426 /* SupabaseDatabaseRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A202A1162CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift */; };
+		FD331A8B2CF33E7100F39426 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1B42CE3BC79009D71DC /* UserDefaultsManager.swift */; };
+		FD331A8C2CF33E7100F39426 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1B22CE3BC68009D71DC /* KeychainManager.swift */; };
+		FD331A8E2CF33F6700F39426 /* SupabaseStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD331A8D2CF33F6100F39426 /* SupabaseStorageManager.swift */; };
+		FD331A8F2CF33F6700F39426 /* SupabaseStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD331A8D2CF33F6100F39426 /* SupabaseStorageManager.swift */; };
 		FD3A033F2CD8CF460047B7ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FD3A03392CD8CF460047B7ED /* Assets.xcassets */; };
 		FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */; };
 		FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A03382CD8CF460047B7ED /* AppDelegate.swift */; };
@@ -136,6 +166,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		FD331A692CF33C6700F39426 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FD3A03182CD8CDE50047B7ED /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FD3A031F2CD8CDE50047B7ED;
+			remoteInfo = SniffMeet;
+		};
 		FD69B1BE2CE3BCDC009D71DC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FD3A03182CD8CDE50047B7ED /* Project object */;
@@ -219,6 +256,10 @@
 		FD119F4D2CED87BC00BE22BD /* SelectLocationPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationPresenter.swift; sourceTree = "<group>"; };
 		FD119F4F2CED87DD00BE22BD /* SelectLocationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationRouter.swift; sourceTree = "<group>"; };
 		FD119F512CED880A00BE22BD /* SelectLocationModuleBuildable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationModuleBuildable.swift; sourceTree = "<group>"; };
+		FD331A5F2CF339AA00F39426 /* SupabaseStorageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseStorageRequest.swift; sourceTree = "<group>"; };
+		FD331A652CF33C6700F39426 /* SupabaseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SupabaseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD331A712CF33C7F00F39426 /* SupabaseStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseStorageTests.swift; sourceTree = "<group>"; };
+		FD331A8D2CF33F6100F39426 /* SupabaseStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseStorageManager.swift; sourceTree = "<group>"; };
 		FD3A03202CD8CDE50047B7ED /* SniffMeet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SniffMeet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD3A03382CD8CF460047B7ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FD3A03392CD8CF460047B7ED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -257,6 +298,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		FD331A622CF33C6700F39426 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FD3A031D2CD8CDE50047B7ED /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -409,6 +457,7 @@
 		A24082622CEB2464009109A0 /* Supabase */ = {
 			isa = PBXGroup;
 			children = (
+				FD331A5E2CF339A400F39426 /* Storage */,
 				A24082602CEB244C009109A0 /* SupabaseConfig.swift */,
 				A20E714F2CEC595C00272B25 /* SupabaseError.swift */,
 				A24082652CEB2475009109A0 /* Auth */,
@@ -504,12 +553,30 @@
 			path = SNMNetwork;
 			sourceTree = "<group>";
 		};
+		FD331A5E2CF339A400F39426 /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				FD331A8D2CF33F6100F39426 /* SupabaseStorageManager.swift */,
+				FD331A5F2CF339AA00F39426 /* SupabaseStorageRequest.swift */,
+			);
+			path = Storage;
+			sourceTree = "<group>";
+		};
+		FD331A6F2CF33C7B00F39426 /* SupabaseTests */ = {
+			isa = PBXGroup;
+			children = (
+				FD331A712CF33C7F00F39426 /* SupabaseStorageTests.swift */,
+			);
+			path = SupabaseTests;
+			sourceTree = "<group>";
+		};
 		FD3A03172CD8CDE50047B7ED = {
 			isa = PBXGroup;
 			children = (
 				FD3A033E2CD8CF460047B7ED /* SniffMeet */,
 				FD69B1C62CE3BCED009D71DC /* SNMPersistenceTests */,
 				FDCD02D42CE9182200B627D8 /* SNMNetworkTests */,
+				FD331A6F2CF33C7B00F39426 /* SupabaseTests */,
 				FD3A03212CD8CDE50047B7ED /* Products */,
 			);
 			sourceTree = "<group>";
@@ -520,6 +587,7 @@
 				FD3A03202CD8CDE50047B7ED /* SniffMeet.app */,
 				FD69B1BA2CE3BCDC009D71DC /* SNMPersistenceTests.xctest */,
 				FDCD02BE2CE9172600B627D8 /* SNMNetworkTests.xctest */,
+				FD331A652CF33C6700F39426 /* SupabaseTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1334,6 +1402,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		FD331A642CF33C6700F39426 /* SupabaseTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FD331A6B2CF33C6700F39426 /* Build configuration list for PBXNativeTarget "SupabaseTests" */;
+			buildPhases = (
+				FD331A612CF33C6700F39426 /* Sources */,
+				FD331A622CF33C6700F39426 /* Frameworks */,
+				FD331A632CF33C6700F39426 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FD331A6A2CF33C6700F39426 /* PBXTargetDependency */,
+			);
+			name = SupabaseTests;
+			packageProductDependencies = (
+			);
+			productName = SupabaseTests;
+			productReference = FD331A652CF33C6700F39426 /* SupabaseTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		FD3A031F2CD8CDE50047B7ED /* SniffMeet */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FD3A03332CD8CDE60047B7ED /* Build configuration list for PBXNativeTarget "SniffMeet" */;
@@ -1400,9 +1488,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1600;
+				LastSwiftUpdateCheck = 1610;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
+					FD331A642CF33C6700F39426 = {
+						CreatedOnToolsVersion = 16.1;
+					};
 					FD3A031F2CD8CDE50047B7ED = {
 						CreatedOnToolsVersion = 16.0;
 					};
@@ -1435,11 +1526,19 @@
 				FD3A031F2CD8CDE50047B7ED /* SniffMeet */,
 				FD69B1B92CE3BCDC009D71DC /* SNMPersistenceTests */,
 				FDCD02BD2CE9172600B627D8 /* SNMNetworkTests */,
+				FD331A642CF33C6700F39426 /* SupabaseTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		FD331A632CF33C6700F39426 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FD3A031E2CD8CDE50047B7ED /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1467,6 +1566,41 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		FD331A612CF33C6700F39426 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD331A8B2CF33E7100F39426 /* UserDefaultsManager.swift in Sources */,
+				FD331A8C2CF33E7100F39426 /* KeychainManager.swift in Sources */,
+				FD331A7D2CF33D0500F39426 /* SupabaseStorageRequest.swift in Sources */,
+				FD331A7E2CF33D0500F39426 /* SupabaseConfig.swift in Sources */,
+				FD331A7F2CF33D0500F39426 /* SupabaseError.swift in Sources */,
+				FD331A802CF33D0500F39426 /* SupabaseAuthManager.swift in Sources */,
+				FD331A812CF33D0500F39426 /* SessionManager.swift in Sources */,
+				FD331A8E2CF33F6700F39426 /* SupabaseStorageManager.swift in Sources */,
+				FD331A822CF33D0500F39426 /* SupabaseRequest.swift in Sources */,
+				FD331A832CF33D0500F39426 /* SupabaseSession.swift in Sources */,
+				FD331A842CF33D0500F39426 /* SupabaseUser.swift in Sources */,
+				FD331A852CF33D0500F39426 /* SupabaseSessionResponse.swift in Sources */,
+				FD331A862CF33D0500F39426 /* SupabaseUserResponse.swift in Sources */,
+				FD331A872CF33D0500F39426 /* SupabaseRefreshResponse.swift in Sources */,
+				FD331A882CF33D0500F39426 /* SupabaseTokenRequest.swift in Sources */,
+				FD331A892CF33D0500F39426 /* SupabaseDatabaseManager.swift in Sources */,
+				FD331A8A2CF33D0500F39426 /* SupabaseDatabaseRequest.swift in Sources */,
+				FD331A732CF33CF200F39426 /* MultipartFormData.swift in Sources */,
+				FD331A742CF33CF200F39426 /* HTTPStatusCode.swift in Sources */,
+				FD331A752CF33CF200F39426 /* NetworkProvider.swift in Sources */,
+				FD331A762CF33CF200F39426 /* SNMRequestType.swift in Sources */,
+				FD331A772CF33CF200F39426 /* SNMRequestConvertible.swift in Sources */,
+				FD331A782CF33CF200F39426 /* Endpoint.swift in Sources */,
+				FD331A792CF33CF200F39426 /* SNMNetworkResponse.swift in Sources */,
+				FD331A7A2CF33CF200F39426 /* Data + append.swift in Sources */,
+				FD331A7B2CF33CF200F39426 /* URLRequest + append.swift in Sources */,
+				FD331A7C2CF33CF200F39426 /* AnyEncodable.swift in Sources */,
+				FD331A722CF33C8400F39426 /* SupabaseStorageTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FD3A031C2CD8CDE50047B7ED /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1478,6 +1612,7 @@
 				A2C844D12CDBE1E5007F2970 /* (null) in Sources */,
 				3200444E2CE595EA00D08B6D /* ProfileCreatePresenter.swift in Sources */,
 				320044922CED78D200D08B6D /* RespondWalkPresenter.swift in Sources */,
+				FD331A8F2CF33F6700F39426 /* SupabaseStorageManager.swift in Sources */,
 				FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */,
 				995D94A82CECEF91005A47BF /* RequestMateViewController.swift in Sources */,
 				A202A1172CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift in Sources */,
@@ -1560,6 +1695,7 @@
 				A2C328862CE245AC00D255AB /* TabBarModuleBuilder.swift in Sources */,
 				320044732CEB47B100D08B6D /* RequestWalkInteractor.swift in Sources */,
 				320044942CED80B700D08B6D /* RespondWalkInteractor.swift in Sources */,
+				FD331A602CF339B000F39426 /* SupabaseStorageRequest.swift in Sources */,
 				320044892CEC862D00D08B6D /* LocationSelectionView.swift in Sources */,
 				FD69B1B52CE3BC7E009D71DC /* UserDefaultsManager.swift in Sources */,
 				320043722CDC9E5F00D08B6D /* (null) in Sources */,
@@ -1614,6 +1750,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		FD331A6A2CF33C6700F39426 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FD3A031F2CD8CDE50047B7ED /* SniffMeet */;
+			targetProxy = FD331A692CF33C6700F39426 /* PBXContainerItemProxy */;
+		};
 		FD3A03472CD8D2C90047B7ED /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = FD3A03462CD8D2C90047B7ED /* SwiftLintBuildToolPlugin */;
@@ -1637,6 +1778,48 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		FD331A6C2CF33C6700F39426 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sole.SupabaseTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		FD331A6D2CF33C6700F39426 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sole.SupabaseTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
 		FD3A03342CD8CDE60047B7ED /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1919,6 +2102,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		FD331A6B2CF33C6700F39426 /* Build configuration list for PBXNativeTarget "SupabaseTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FD331A6C2CF33C6700F39426 /* Debug */,
+				FD331A6D2CF33C6700F39426 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FD3A031B2CD8CDE50047B7ED /* Build configuration list for PBXProject "SniffMeet" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		FD69B1CB2CE3E9B4009D71DC /* UserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1CA2CE3E9B4009D71DC /* UserDefaultsTests.swift */; };
 		FD69B1CD2CE3E9BB009D71DC /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1CC2CE3E9B8009D71DC /* KeychainTests.swift */; };
 		FD880B5A2CECE8FC0093BEB9 /* SNMLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD880B592CECE8F90093BEB9 /* SNMLogger.swift */; };
+		FD880B602CF4327F0093BEB9 /* SaveProfileImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD880B5F2CF432780093BEB9 /* SaveProfileImageUseCase.swift */; };
+		FD880B622CF433AF0093BEB9 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD880B612CF433AC0093BEB9 /* Environment.swift */; };
 		FDA04AA52CE91DBF002605AC /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA04AA42CE91DB7002605AC /* MultipartFormData.swift */; };
 		FDA04AA62CE91DBF002605AC /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA04AA42CE91DB7002605AC /* MultipartFormData.swift */; };
 		FDA04AA82CE91DF8002605AC /* Data + append.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA04AA72CE91DF4002605AC /* Data + append.swift */; };
@@ -278,6 +280,8 @@
 		FD69B1CA2CE3E9B4009D71DC /* UserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsTests.swift; sourceTree = "<group>"; };
 		FD69B1CC2CE3E9B8009D71DC /* KeychainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainTests.swift; sourceTree = "<group>"; };
 		FD880B592CECE8F90093BEB9 /* SNMLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMLogger.swift; sourceTree = "<group>"; };
+		FD880B5F2CF432780093BEB9 /* SaveProfileImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveProfileImageUseCase.swift; sourceTree = "<group>"; };
+		FD880B612CF433AC0093BEB9 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		FDA04AA42CE91DB7002605AC /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		FDA04AA72CE91DF4002605AC /* Data + append.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data + append.swift"; sourceTree = "<group>"; };
 		FDA04AAA2CE92358002605AC /* MultipartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataTests.swift; sourceTree = "<group>"; };
@@ -363,6 +367,7 @@
 		320044782CEC48FB00D08B6D /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				FD880B5F2CF432780093BEB9 /* SaveProfileImageUseCase.swift */,
 				FD119F492CED875800BE22BD /* RequestUserLocationUseCase.swift */,
 				FD119F472CED872500BE22BD /* RequestLocationAuthUseCase.swift */,
 				FD119F452CED867600BE22BD /* ConvertLocationToTextUseCase.swift */,
@@ -524,6 +529,7 @@
 		A2C844CF2CDBE1CB007F2970 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				FD880B612CF433AC0093BEB9 /* Environment.swift */,
 				320044842CEC836000D08B6D /* PaddingLabel.swift */,
 				FD880B592CECE8F90093BEB9 /* SNMLogger.swift */,
 				FD5134162CEB7388002E76F3 /* UIControl + Publisher.swift */,
@@ -1488,7 +1494,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1610;
+				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					FD331A642CF33C6700F39426 = {
@@ -1657,6 +1663,7 @@
 				320044962CED80DA00D08B6D /* RespondWalkRouter.swift in Sources */,
 				320043912CDF3D7F00D08B6D /* KeywordButton.swift in Sources */,
 				FD119F4C2CED87B000BE22BD /* SelectLocationInteractor.swift in Sources */,
+				FD880B622CF433AF0093BEB9 /* Environment.swift in Sources */,
 				320043922CDF3D7F00D08B6D /* InputTextField.swift in Sources */,
 				FD119F482CED872C00BE22BD /* RequestLocationAuthUseCase.swift in Sources */,
 				FD119F422CED865B00BE22BD /* SelectLocationViewController.swift in Sources */,
@@ -1687,6 +1694,7 @@
 				A2C844D72CDBEF8B007F2970 /* (null) in Sources */,
 				3200438B2CDF3BEF00D08B6D /* ProfileCreateViewController.swift in Sources */,
 				FD119F502CED87E500BE22BD /* SelectLocationRouter.swift in Sources */,
+				FD880B602CF4327F0093BEB9 /* SaveProfileImageUseCase.swift in Sources */,
 				320044672CE6125100D08B6D /* DataManager.swift in Sources */,
 				3200449C2CEDA87800D08B6D /* RespondWalkRequestUseCase.swift in Sources */,
 				FDEAEA7A2CE3148D005890FA /* BaseView.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
@@ -5,12 +5,16 @@
 //  Created by 윤지성 on 11/14/24.
 //
 
+import Foundation
+import UIKit
+
 protocol ProfileCreateInteractable: AnyObject {
     var presenter: DogInfoInteractorOutput? { get set }
     var storeDogInfoUseCase: StoreDogInfoUseCase { get set }
     var saveProfileImageUseCase: SaveProfileImageUseCase { get }
 
     func signInWithProfileData(dogInfo: Dog)
+    func convertImageToData(image: UIImage?) -> Data?
 }
 
 final class ProfileCreateInteractor: ProfileCreateInteractable {
@@ -41,5 +45,9 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
                 presenter?.didFailToSaveDogInfo(error: error)
             }
         }
+    }
+    func convertImageToData(image: UIImage?) -> Data? {
+        guard let image else { return nil }
+        return image.pngData()
     }
 }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
@@ -12,7 +12,7 @@ protocol ProfileCreatePresentable : AnyObject{
     var interactor: ProfileCreateInteractable? { get set }
     var router: ProfileCreateRoutable? { get set }
     
-    func saveDogInfo(nickname: String, imageData: Data?)
+    func didTapSubmitButton(nickname: String, imageData: Data?)
 }
 
 protocol DogInfoInteractorOutput: AnyObject {
@@ -37,9 +37,9 @@ final class ProfileCreatePresenter: ProfileCreatePresentable {
         self.interactor = interactor
         self.router = router
     }
-    
-    func saveDogInfo(nickname: String, imageData: Data?) {
-        let dog = Dog(name: dogInfo.name,
+
+    func didTapSubmitButton(nickname: String, imageData: Data?) {
+        let dogInfo = Dog(name: dogInfo.name,
                       age: dogInfo.age,
                       sex: dogInfo.sex,
                       sexUponIntake: dogInfo.sexUponIntake,
@@ -47,17 +47,20 @@ final class ProfileCreatePresenter: ProfileCreatePresentable {
                       keywords: dogInfo.keywords,
                       nickname: nickname,
                       profileImage: imageData)
-        interactor?.saveDogInfo(dogInfo: dog)
+        // TODO: SubmitButton disable 필요
+        interactor?.signInWithProfileData(dogInfo: dogInfo)
     }
 }
 
 extension ProfileCreatePresenter: DogInfoInteractorOutput {
     func didSaveDogInfo() {
+        // TODO: submit button enable
         guard let view else { return }
         router?.presentMainScreen(from: view)
     }
     
     func didFailToSaveDogInfo(error: any Error) {
         // TODO: -  alert 올리는데 어떻게 올릴지 정하기
+        // TODO: submit button enable
     }
 }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
@@ -5,6 +5,7 @@
 //  Created by 윤지성 on 11/14/24.
 //
 import Foundation
+import UIKit
 
 protocol ProfileCreatePresentable : AnyObject{
     var dogInfo: DogDetailInfo { get set }
@@ -12,7 +13,7 @@ protocol ProfileCreatePresentable : AnyObject{
     var interactor: ProfileCreateInteractable? { get set }
     var router: ProfileCreateRoutable? { get set }
     
-    func didTapSubmitButton(nickname: String, imageData: Data?)
+    func didTapSubmitButton(nickname: String, image: UIImage?)
 }
 
 protocol DogInfoInteractorOutput: AnyObject {
@@ -38,7 +39,8 @@ final class ProfileCreatePresenter: ProfileCreatePresentable {
         self.router = router
     }
 
-    func didTapSubmitButton(nickname: String, imageData: Data?) {
+    func didTapSubmitButton(nickname: String, image: UIImage?) {
+        let imageData = interactor?.convertImageToData(image: image)
         let dogInfo = Dog(name: dogInfo.name,
                       age: dogInfo.age,
                       sex: dogInfo.sex,

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
@@ -16,11 +16,13 @@ protocol ProfileCreateBuildable {
 
 final class ProfileCreateRouter: ProfileCreateRoutable {
     func presentMainScreen(from view: any ProfileCreateViewable) {
-        if let sceneDelegate = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive })?
-            .delegate as? SceneDelegate {
-            if let router = sceneDelegate.appRouter {
-                router.moveToHomeScreen()
+        Task { @MainActor in
+            if let sceneDelegate = UIApplication.shared.connectedScenes
+                .first(where: { $0.activationState == .foregroundActive })?
+                .delegate as? SceneDelegate {
+                if let router = sceneDelegate.appRouter {
+                    router.moveToHomeScreen()
+                }
             }
         }
     }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
@@ -30,12 +30,22 @@ extension ProfileCreateRouter: ProfileCreateBuildable {
     static func createProfileCreateModule(dogDetailInfo: DogDetailInfo) -> UIViewController {
         let storeDogInfoUsecase: StoreDogInfoUseCase =
         StoreDogInfoUseCaseImpl(localDataManager: LocalDataManager())
+        let saveProfileImageUsecase: SaveProfileImageUseCase =
+        SaveProfileImageUseCaseImpl(
+            remoteImageManager: SupabaseStorageManager(
+                networkProvider: SNMNetworkProvider()
+            ),
+            userDefaultsManager: UserDefaultsManager.shared
+        )
 
         let view: ProfileCreateViewable & UIViewController = ProfileCreateViewController()
         let presenter: ProfileCreatePresentable & DogInfoInteractorOutput
         = ProfileCreatePresenter(dogInfo: dogDetailInfo)
         let interactor: ProfileCreateInteractable =
-        ProfileCreateInteractor(usecase: storeDogInfoUsecase)
+        ProfileCreateInteractor(
+            storeDogInfoUsecase: storeDogInfoUsecase,
+            saveProfileImageUseCase: saveProfileImageUsecase
+        )
         let router: ProfileCreateRoutable & ProfileCreateBuildable = ProfileCreateRouter()
 
         view.presenter = presenter

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
@@ -141,9 +141,9 @@ private extension ProfileCreateViewController {
             // approuter를 통해서 화면전환을 수행한다. window를 다르게 설정해야 할듯
             // FIXME: File 저장 방식 변경 필요
             guard let nickname = self?.nicknameTextField.text else { return }
-            self?.presenter?.saveDogInfo(
+            self?.presenter?.didTapSubmitButton(
                 nickname: nickname,
-                imageData: self?.profileImageView.image?.jpegData(compressionQuality: 1)
+                imageData: self?.profileImageView.image?.pngData()
             )
         }, for: .touchUpInside)
     }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
@@ -143,7 +143,7 @@ private extension ProfileCreateViewController {
             guard let nickname = self?.nicknameTextField.text else { return }
             self?.presenter?.didTapSubmitButton(
                 nickname: nickname,
-                imageData: self?.profileImageView.image?.pngData()
+                image: self?.profileImageView.image
             )
         }, for: .touchUpInside)
     }

--- a/SniffMeet/SniffMeet/Source/Common/Environment.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Environment.swift
@@ -1,0 +1,19 @@
+//
+//  Environment.swift
+//  SniffMeet
+//
+//  Created by sole on 11/25/24.
+//
+
+enum Environment {
+    enum UserDefaultsKey {
+        static let profileImage: String = "profileImage"
+        static let dogInfo: String = "dogInfo"
+        static let expiresAt: String = "expiresAt"
+    }
+
+    enum KeychainKey {
+        static let accessToken: String = "accessToken"
+        static let refreshToken: String = "refreshToken"
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Supabase/Storage/SupabaseStorageManager.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Storage/SupabaseStorageManager.swift
@@ -1,0 +1,48 @@
+//
+//  SupabaseStorageManager.swift
+//  SniffMeet
+//
+//  Created by sole on 11/24/24.
+//
+
+import Foundation
+
+protocol RemoteImageManagable {
+    func upload(imageData: Data, fileName: String, mimeType: MimeType) async throws
+    func download(fileName: String) async throws -> Data
+}
+
+struct SupabaseStorageManager: RemoteImageManagable {
+    private let networkProvider: SNMNetworkProvider
+
+    init(networkProvider: SNMNetworkProvider) {
+        self.networkProvider = networkProvider
+    }
+
+    func upload(
+        imageData: Data,
+        fileName: String,
+        mimeType: MimeType = .image
+    ) async throws {
+        if SessionManager.shared.isExpired {
+            try await SupabaseAuthManager.shared.refreshSession()
+        }
+        guard let session = SessionManager.shared.session else {
+            throw SupabaseError.sessionNotExist
+        }
+        _ = try await networkProvider.request(
+            with: SupabaseStorageRequest.upload(
+                accessToken: session.accessToken,
+                image: imageData,
+                fileName: fileName,
+                mimeType: mimeType
+            )
+        )
+    }
+    func download(fileName: String) async throws -> Data {
+        let response = try await networkProvider.request(
+            with: SupabaseStorageRequest.download(fileName: fileName)
+        )
+        return response.data
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Supabase/Storage/SupabaseStorageRequest.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Storage/SupabaseStorageRequest.swift
@@ -1,0 +1,77 @@
+//
+//  SupabaseStorageRequest.swift
+//  SniffMeet
+//
+//  Created by sole on 11/24/24.
+//
+
+import Foundation
+
+enum SupabaseStorageRequest {
+    case upload(
+        accessToken: String,
+        image: Data,
+        fileName: String,
+        mimeType: MimeType
+    )
+    case download(fileName: String)
+}
+
+//MARK: - SupabaseStorageRequest+SNMRequestConvertible
+
+extension SupabaseStorageRequest: SNMRequestConvertible {
+    var endpoint: Endpoint {
+        switch self {
+        case .upload(_, _, let fileName, _):
+            Endpoint(
+                baseURL: SupabaseConfig.baseURL,
+                path: "storage/v1/object/\(SupabaseConfig.bucketName)/\(fileName)",
+                method: .post
+            )
+        case .download(let fileName):
+            Endpoint(
+                baseURL: SupabaseConfig.baseURL,
+                path: "storage/v1/object/\(SupabaseConfig.bucketName)/\(fileName)",
+                method: .get
+            )
+        }
+    }
+
+    var requestType: SNMRequestType {
+        switch self {
+        case .upload(let accessToken, let imageData, let fileName, let mimeType):
+                .multipartFormData(
+                    header: [
+                        "apiKey" : SupabaseConfig.apiKey,
+                        "Authorization" : "Bearer \(accessToken)"
+                    ],
+                    multipartFormData: MultipartFormData(
+                        parameters: [:],
+                        fileName: fileName,
+                        mimeType: mimeType.value,
+                        contentData: imageData
+                    )
+                )
+        case .download:
+                .header(with: [
+                    "apiKey" : SupabaseConfig.apiKey
+                ])
+        }
+    }
+}
+
+enum MimeType {
+    case plainText
+    case imageJPEG
+    case imagePNG
+    case image
+
+    var value: String {
+        switch self {
+        case .plainText: "text/plain"
+        case .imageJPEG: "image/jpeg"
+        case .imagePNG: "image/png"
+        case .image: "image/*"
+        }
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Supabase/SupabaseConfig.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/SupabaseConfig.swift
@@ -10,4 +10,5 @@ import Foundation
 enum SupabaseConfig {
     static let baseURL = URL(string: "https://lltjsznuclppbhxfwslo.supabase.co")!
     static let apiKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxsdGpzem51Y2xwcGJoeGZ3c2xvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzE0MDA5MjgsImV4cCI6MjA0Njk3NjkyOH0.qrzmB2tiwWevRhKQeptsf5m8iCLUIkscuQ1MzKNtqh4" // 공개키
+    static let bucketName: String = "image"
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveProfileImageUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveProfileImageUseCase.swift
@@ -1,0 +1,40 @@
+//
+//  SaveProfileImageUseCase.swift
+//  SniffMeet
+//
+//  Created by sole on 11/25/24.
+//
+
+import Foundation
+
+protocol SaveProfileImageUseCase {
+    /// fileName을 반환합니다.
+    func execute(imageData: Data) async throws -> String
+}
+
+struct SaveProfileImageUseCaseImpl: SaveProfileImageUseCase {
+    private let remoteImageManager: any RemoteImageManagable
+    private let userDefaultsManager: any UserDefaultsManagable
+
+    init(
+        remoteImageManager: any RemoteImageManagable,
+        userDefaultsManager: any UserDefaultsManagable
+    ) {
+        self.remoteImageManager = remoteImageManager
+        self.userDefaultsManager = userDefaultsManager
+    }
+
+    func execute(imageData: Data) async throws -> String {
+        let fileName: String = UUID().uuidString
+        try await remoteImageManager.upload(
+            imageData: imageData,
+            fileName: fileName,
+            mimeType: .image
+        )
+        try userDefaultsManager.set(
+            value: fileName,
+            forKey: Environment.UserDefaultsKey.profileImage
+        )
+        return fileName
+    }
+}

--- a/SniffMeet/SupabaseTests/SupabaseStorageTests.swift
+++ b/SniffMeet/SupabaseTests/SupabaseStorageTests.swift
@@ -1,0 +1,33 @@
+//
+//  SupabaseStorageTests.swift
+//  SniffMeet
+//
+//  Created by sole on 11/24/24.
+//
+
+import UIKit
+import XCTest
+
+final class SupabaseStorageTests: XCTestCase {
+    private var storageManager: (any RemoteImageManagable)!
+
+    override func setUp() {
+        self.storageManager = SupabaseStorageManager(
+            networkProvider: SNMNetworkProvider()
+        )
+    }
+
+    func test_이미지_다운로드후_이미지_변환에_성공해야_한다() async throws {
+        // given
+        // when
+        let imageData = try await storageManager.download(fileName: "8AA2442D-1E09-41BC-BE92-50AC65C19367")
+        // then
+        XCTAssertNotNil(UIImage(data: imageData))
+    }
+    func test_이미지를_데이터로_변환후_업로드에_성공해야_한다() async throws {
+        // given
+        let image = UIImage(systemName: "square.and.arrow.up.fill")!
+        let imageData = image.jpegData(compressionQuality: 1)!
+        try await storageManager.upload(imageData: imageData, fileName: UUID().uuidString, mimeType: .image)
+    }
+}


### PR DESCRIPTION
### 🔖  Issue Number

close #87 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- 공용 bucket 이름 `SupabaseConfig`로 분리 
일단은 image로 버킷이 생성되어 있어서 image로 이름을 설정해두었습니다. 버킷 이름은 같이 정해보면 좋을 것 같습니다. 

- download / upload image 구현 

아래와 같은 인터페이스를 구현한 뒤 `SupabaseStorageManager` 구체타입에 `SupabaseStorageRequest`를 통해 구현했습니다. 
``` swift 
protocol RemoteImageManagable {
    func upload(imageData: Data, fileName: String, mimeType: MimeType) async throws
    func download(fileName: String) async throws -> Data
}
```

아래와 같이 사용할 수 있습니다. 

``` swift 
let imageData = try await storageManager.download(fileName: "cat.png")
try await storageManager.upload(imageData: imageData, fileName: UUID().uuidString, mimeType: .image)
```

### PR 특이사항 

업로드의 경우 accessToken이 필요해서 PR엔 올라가지 않았지만 테스트 전 session을 주입해주는 방식으로 해결했습니다. 
``` swift 
SessionManager.shared.session = .init(
            accessToken: "accessToken",
            expiresAt: 12312313,
            refreshToken: "hgddd"
        )
```
