### PR TITLE
[feat] 프로필 이미지 저장 로직 구현 

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		FD69B1CB2CE3E9B4009D71DC /* UserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1CA2CE3E9B4009D71DC /* UserDefaultsTests.swift */; };
 		FD69B1CD2CE3E9BB009D71DC /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B1CC2CE3E9B8009D71DC /* KeychainTests.swift */; };
 		FD880B5A2CECE8FC0093BEB9 /* SNMLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD880B592CECE8F90093BEB9 /* SNMLogger.swift */; };
+		FD880B602CF4327F0093BEB9 /* SaveProfileImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD880B5F2CF432780093BEB9 /* SaveProfileImageUseCase.swift */; };
+		FD880B622CF433AF0093BEB9 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD880B612CF433AC0093BEB9 /* Environment.swift */; };
 		FDA04AA52CE91DBF002605AC /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA04AA42CE91DB7002605AC /* MultipartFormData.swift */; };
 		FDA04AA62CE91DBF002605AC /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA04AA42CE91DB7002605AC /* MultipartFormData.swift */; };
 		FDA04AA82CE91DF8002605AC /* Data + append.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA04AA72CE91DF4002605AC /* Data + append.swift */; };
@@ -278,6 +280,8 @@
 		FD69B1CA2CE3E9B4009D71DC /* UserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsTests.swift; sourceTree = "<group>"; };
 		FD69B1CC2CE3E9B8009D71DC /* KeychainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainTests.swift; sourceTree = "<group>"; };
 		FD880B592CECE8F90093BEB9 /* SNMLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMLogger.swift; sourceTree = "<group>"; };
+		FD880B5F2CF432780093BEB9 /* SaveProfileImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveProfileImageUseCase.swift; sourceTree = "<group>"; };
+		FD880B612CF433AC0093BEB9 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		FDA04AA42CE91DB7002605AC /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		FDA04AA72CE91DF4002605AC /* Data + append.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data + append.swift"; sourceTree = "<group>"; };
 		FDA04AAA2CE92358002605AC /* MultipartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataTests.swift; sourceTree = "<group>"; };
@@ -363,6 +367,7 @@
 		320044782CEC48FB00D08B6D /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				FD880B5F2CF432780093BEB9 /* SaveProfileImageUseCase.swift */,
 				FD119F492CED875800BE22BD /* RequestUserLocationUseCase.swift */,
 				FD119F472CED872500BE22BD /* RequestLocationAuthUseCase.swift */,
 				FD119F452CED867600BE22BD /* ConvertLocationToTextUseCase.swift */,
@@ -524,6 +529,7 @@
 		A2C844CF2CDBE1CB007F2970 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				FD880B612CF433AC0093BEB9 /* Environment.swift */,
 				320044842CEC836000D08B6D /* PaddingLabel.swift */,
 				FD880B592CECE8F90093BEB9 /* SNMLogger.swift */,
 				FD5134162CEB7388002E76F3 /* UIControl + Publisher.swift */,
@@ -1488,7 +1494,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1610;
+				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					FD331A642CF33C6700F39426 = {
@@ -1657,6 +1663,7 @@
 				320044962CED80DA00D08B6D /* RespondWalkRouter.swift in Sources */,
 				320043912CDF3D7F00D08B6D /* KeywordButton.swift in Sources */,
 				FD119F4C2CED87B000BE22BD /* SelectLocationInteractor.swift in Sources */,
+				FD880B622CF433AF0093BEB9 /* Environment.swift in Sources */,
 				320043922CDF3D7F00D08B6D /* InputTextField.swift in Sources */,
 				FD119F482CED872C00BE22BD /* RequestLocationAuthUseCase.swift in Sources */,
 				FD119F422CED865B00BE22BD /* SelectLocationViewController.swift in Sources */,
@@ -1687,6 +1694,7 @@
 				A2C844D72CDBEF8B007F2970 /* (null) in Sources */,
 				3200438B2CDF3BEF00D08B6D /* ProfileCreateViewController.swift in Sources */,
 				FD119F502CED87E500BE22BD /* SelectLocationRouter.swift in Sources */,
+				FD880B602CF4327F0093BEB9 /* SaveProfileImageUseCase.swift in Sources */,
 				320044672CE6125100D08B6D /* DataManager.swift in Sources */,
 				3200449C2CEDA87800D08B6D /* RespondWalkRequestUseCase.swift in Sources */,
 				FDEAEA7A2CE3148D005890FA /* BaseView.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
@@ -5,12 +5,16 @@
 //  Created by 윤지성 on 11/14/24.
 //
 
+import Foundation
+import UIKit
+
 protocol ProfileCreateInteractable: AnyObject {
     var presenter: DogInfoInteractorOutput? { get set }
     var storeDogInfoUseCase: StoreDogInfoUseCase { get set }
     var saveProfileImageUseCase: SaveProfileImageUseCase { get }
 
     func signInWithProfileData(dogInfo: Dog)
+    func convertImageToData(image: UIImage?) -> Data?
 }
 
 final class ProfileCreateInteractor: ProfileCreateInteractable {
@@ -41,5 +45,9 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
                 presenter?.didFailToSaveDogInfo(error: error)
             }
         }
+    }
+    func convertImageToData(image: UIImage?) -> Data? {
+        guard let image else { return nil }
+        return image.pngData()
     }
 }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
@@ -12,7 +12,7 @@ protocol ProfileCreatePresentable : AnyObject{
     var interactor: ProfileCreateInteractable? { get set }
     var router: ProfileCreateRoutable? { get set }
     
-    func saveDogInfo(nickname: String, imageData: Data?)
+    func didTapSubmitButton(nickname: String, imageData: Data?)
 }
 
 protocol DogInfoInteractorOutput: AnyObject {
@@ -37,9 +37,9 @@ final class ProfileCreatePresenter: ProfileCreatePresentable {
         self.interactor = interactor
         self.router = router
     }
-    
-    func saveDogInfo(nickname: String, imageData: Data?) {
-        let dog = Dog(name: dogInfo.name,
+
+    func didTapSubmitButton(nickname: String, imageData: Data?) {
+        let dogInfo = Dog(name: dogInfo.name,
                       age: dogInfo.age,
                       sex: dogInfo.sex,
                       sexUponIntake: dogInfo.sexUponIntake,
@@ -47,17 +47,20 @@ final class ProfileCreatePresenter: ProfileCreatePresentable {
                       keywords: dogInfo.keywords,
                       nickname: nickname,
                       profileImage: imageData)
-        interactor?.saveDogInfo(dogInfo: dog)
+        // TODO: SubmitButton disable 필요
+        interactor?.signInWithProfileData(dogInfo: dogInfo)
     }
 }
 
 extension ProfileCreatePresenter: DogInfoInteractorOutput {
     func didSaveDogInfo() {
+        // TODO: submit button enable
         guard let view else { return }
         router?.presentMainScreen(from: view)
     }
     
     func didFailToSaveDogInfo(error: any Error) {
         // TODO: -  alert 올리는데 어떻게 올릴지 정하기
+        // TODO: submit button enable
     }
 }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
@@ -5,6 +5,7 @@
 //  Created by 윤지성 on 11/14/24.
 //
 import Foundation
+import UIKit
 
 protocol ProfileCreatePresentable : AnyObject{
     var dogInfo: DogDetailInfo { get set }
@@ -12,7 +13,7 @@ protocol ProfileCreatePresentable : AnyObject{
     var interactor: ProfileCreateInteractable? { get set }
     var router: ProfileCreateRoutable? { get set }
     
-    func didTapSubmitButton(nickname: String, imageData: Data?)
+    func didTapSubmitButton(nickname: String, image: UIImage?)
 }
 
 protocol DogInfoInteractorOutput: AnyObject {
@@ -38,7 +39,8 @@ final class ProfileCreatePresenter: ProfileCreatePresentable {
         self.router = router
     }
 
-    func didTapSubmitButton(nickname: String, imageData: Data?) {
+    func didTapSubmitButton(nickname: String, image: UIImage?) {
+        let imageData = interactor?.convertImageToData(image: image)
         let dogInfo = Dog(name: dogInfo.name,
                       age: dogInfo.age,
                       sex: dogInfo.sex,

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
@@ -16,11 +16,13 @@ protocol ProfileCreateBuildable {
 
 final class ProfileCreateRouter: ProfileCreateRoutable {
     func presentMainScreen(from view: any ProfileCreateViewable) {
-        if let sceneDelegate = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive })?
-            .delegate as? SceneDelegate {
-            if let router = sceneDelegate.appRouter {
-                router.moveToHomeScreen()
+        Task { @MainActor in
+            if let sceneDelegate = UIApplication.shared.connectedScenes
+                .first(where: { $0.activationState == .foregroundActive })?
+                .delegate as? SceneDelegate {
+                if let router = sceneDelegate.appRouter {
+                    router.moveToHomeScreen()
+                }
             }
         }
     }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
@@ -30,12 +30,22 @@ extension ProfileCreateRouter: ProfileCreateBuildable {
     static func createProfileCreateModule(dogDetailInfo: DogDetailInfo) -> UIViewController {
         let storeDogInfoUsecase: StoreDogInfoUseCase =
         StoreDogInfoUseCaseImpl(localDataManager: LocalDataManager())
+        let saveProfileImageUsecase: SaveProfileImageUseCase =
+        SaveProfileImageUseCaseImpl(
+            remoteImageManager: SupabaseStorageManager(
+                networkProvider: SNMNetworkProvider()
+            ),
+            userDefaultsManager: UserDefaultsManager.shared
+        )
 
         let view: ProfileCreateViewable & UIViewController = ProfileCreateViewController()
         let presenter: ProfileCreatePresentable & DogInfoInteractorOutput
         = ProfileCreatePresenter(dogInfo: dogDetailInfo)
         let interactor: ProfileCreateInteractable =
-        ProfileCreateInteractor(usecase: storeDogInfoUsecase)
+        ProfileCreateInteractor(
+            storeDogInfoUsecase: storeDogInfoUsecase,
+            saveProfileImageUseCase: saveProfileImageUsecase
+        )
         let router: ProfileCreateRoutable & ProfileCreateBuildable = ProfileCreateRouter()
 
         view.presenter = presenter

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
@@ -141,9 +141,9 @@ private extension ProfileCreateViewController {
             // approuter를 통해서 화면전환을 수행한다. window를 다르게 설정해야 할듯
             // FIXME: File 저장 방식 변경 필요
             guard let nickname = self?.nicknameTextField.text else { return }
-            self?.presenter?.saveDogInfo(
+            self?.presenter?.didTapSubmitButton(
                 nickname: nickname,
-                imageData: self?.profileImageView.image?.jpegData(compressionQuality: 1)
+                imageData: self?.profileImageView.image?.pngData()
             )
         }, for: .touchUpInside)
     }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
@@ -143,7 +143,7 @@ private extension ProfileCreateViewController {
             guard let nickname = self?.nicknameTextField.text else { return }
             self?.presenter?.didTapSubmitButton(
                 nickname: nickname,
-                imageData: self?.profileImageView.image?.pngData()
+                image: self?.profileImageView.image
             )
         }, for: .touchUpInside)
     }

--- a/SniffMeet/SniffMeet/Source/Common/Environment.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Environment.swift
@@ -1,0 +1,19 @@
+//
+//  Environment.swift
+//  SniffMeet
+//
+//  Created by sole on 11/25/24.
+//
+
+enum Environment {
+    enum UserDefaultsKey {
+        static let profileImage: String = "profileImage"
+        static let dogInfo: String = "dogInfo"
+        static let expiresAt: String = "expiresAt"
+    }
+
+    enum KeychainKey {
+        static let accessToken: String = "accessToken"
+        static let refreshToken: String = "refreshToken"
+    }
+}

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveProfileImageUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveProfileImageUseCase.swift
@@ -1,0 +1,40 @@
+//
+//  SaveProfileImageUseCase.swift
+//  SniffMeet
+//
+//  Created by sole on 11/25/24.
+//
+
+import Foundation
+
+protocol SaveProfileImageUseCase {
+    /// fileName을 반환합니다.
+    func execute(imageData: Data) async throws -> String
+}
+
+struct SaveProfileImageUseCaseImpl: SaveProfileImageUseCase {
+    private let remoteImageManager: any RemoteImageManagable
+    private let userDefaultsManager: any UserDefaultsManagable
+
+    init(
+        remoteImageManager: any RemoteImageManagable,
+        userDefaultsManager: any UserDefaultsManagable
+    ) {
+        self.remoteImageManager = remoteImageManager
+        self.userDefaultsManager = userDefaultsManager
+    }
+
+    func execute(imageData: Data) async throws -> String {
+        let fileName: String = UUID().uuidString
+        try await remoteImageManager.upload(
+            imageData: imageData,
+            fileName: fileName,
+            mimeType: .image
+        )
+        try userDefaultsManager.set(
+            value: fileName,
+            forKey: Environment.UserDefaultsKey.profileImage
+        )
+        return fileName
+    }
+}


### PR DESCRIPTION
### 🔖  Issue Number

close #91 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- Environment 환경 변수를 추가했습니다. 
- SaveProfileImageUseCase를 구현했습니다. 
- 익명로그인 진행후 이미지를 저장하는 로직을 구현했습니다. (Presenter, Interactor)

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
-  Router 백그라운드 
화면 전환은 UI 작업이므로 반드시 메인 스레드에서 동작해야 하는데요. 우리 Router는 @MainActor와 같은 제약을 걸어두지 않았기 때문에 각각의 라우팅 메서드마다 메인스레드로 보내주는 작업이 필요하더라구요. 
Router에 @MainActor 제약을 걸어주면 수정해야 할 부분이 너무 많아져서 일단은 Router 내부 메서드를 MainActor로 감싸는 방식으로 해결했습니다. 

혹시 좋은 방법 생각나시는분... 삐삐 쳐주십셔~~..

``` swift 
// Interactor 
func signInWithProfileData(dogInfo: Dog) {
        Task {
            do {
                await SupabaseAuthManager.shared.signInAnonymously()
                // ,, 중략 
				// 해당 코드에서 background thread 진입 
                presenter?.didSaveDogInfo()
            } catch {
                presenter?.didFailToSaveDogInfo(error: error)
            }
        }
    }

// Presenter 
func didSaveDogInfo() {
		// background에서 router에게 화면 전환 요청 -> 크래시 
        router?.presentMainScreen(from: view)
    }
```

