### PR TITLE
[feat] Profile Drop 동작시 로컬 DB에서 가져와 데이터 표시

### DIFF
--- a/SniffMeet/SniffMeet/Resource/Info.plist
+++ b/SniffMeet/SniffMeet/Resource/Info.plist
@@ -2,10 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>&apos;SniffMEET&apos;은 P2P 연결을 지원하기 위해 로컬 네트워크 환경이 필요합니다.</string>
 	<key>NSCameraUsageDescription</key>
-	<string>이 앱은 Nearby Interaction과 ARKit을 위해 카메라 접근이 필요합니다.</string>
+	<string>&apos;SniffMEET&apos;은 Nearby Interaction과 ARKit을 위해 카메라 접근이 필요합니다.</string>
 	<key>NSNearbyInteractionUsageDescription</key>
-	<string>This app demonstrates the NearbyInteraction framework. Supply a value for this string to explain how the user benefits when they allow the app to use NearbyInteraction.</string>
+	<string>&apos;SniffMEET&apos;은 연결된 기기와의 거리와 방향 측정을 위해 Nearby Interaction 접근이 필요합니다.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_SniffMeet._tcp</string>

--- a/SniffMeet/SniffMeet/Source/Entity/Dog.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/Dog.swift
@@ -72,3 +72,9 @@ struct DogProfileInfo: Codable {
     let keywords: [Keyword]
     let profileImage: Data?
 }
+
+extension DogProfileInfo {
+    static let example: DogProfileInfo = DogProfileInfo(name: "후추",
+                                                        keywords: [.shy],
+                                                        profileImage: nil)
+}

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/Presenter/RequestMatePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/Presenter/RequestMatePresenter.swift
@@ -20,6 +20,5 @@ final class RequestMatePresenter: RequestMatePresentable {
     }
 
     func didFetchDogProfile(_ dogProfile: DogProfileInfo) {
-        view?.updateView(with: dogProfile)
     }
 }

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol RequestMateViewable: AnyObject {
-    func updateView(with profile: DogProfileInfo)
+    var presenter: RequestMatePresentable? { get set }
 }
 
 final class RequestMateViewController: BaseViewController, RequestMateViewable {
@@ -36,10 +36,8 @@ final class RequestMateViewController: BaseViewController, RequestMateViewable {
     }
 
     override func configureAttributes() {
-//        let placeholderImage = UIImage(named: "placeholder")
-//        profileImageView.image = UIImage(data: profile.profileImage!)
-        profileImageView.image = UIImage(named: "placeholder")
-        profileImageView.contentMode = .scaleAspectFill
+        profileImageView.image = UIImage(data: profile.profileImage!)
+        profileImageView.contentMode = .scaleToFill
         profileImageView.translatesAutoresizingMaskIntoConstraints = false
         nameLabel.text = profile.name
         nameLabel.textColor = SNMColor.white
@@ -131,15 +129,6 @@ final class RequestMateViewController: BaseViewController, RequestMateViewable {
         NSLayoutConstraint.activate(constraints)
     }
     override func bind() {}
-
-    func updateView(with profile: DogProfileInfo) {
-        if let profileImageData = profile.profileImage {
-            let uiImage = UIImage(data: profileImageData)
-            profileImageView.image = uiImage
-        }
-        nameLabel.text = profile.name
-        keywords = profile.keywords
-    }
 }
 
 private extension RequestMateViewController {

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
@@ -37,7 +37,7 @@ final class RequestMateViewController: BaseViewController, RequestMateViewable {
 
     override func configureAttributes() {
         profileImageView.image = UIImage(data: profile.profileImage!)
-        profileImageView.contentMode = .scaleToFill
+        profileImageView.contentMode = .scaleAspectFill
         profileImageView.translatesAutoresizingMaskIntoConstraints = false
         nameLabel.text = profile.name
         nameLabel.textColor = SNMColor.white
@@ -88,6 +88,8 @@ final class RequestMateViewController: BaseViewController, RequestMateViewable {
         let constraints = [
             profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             profileImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            profileImageView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            profileImageView.heightAnchor.constraint(equalTo: view.heightAnchor),
             nameLabel.bottomAnchor.constraint(
                 equalTo: keywordStackView.topAnchor,
                 constant: -LayoutConstant.smallVerticalPadding


### PR DESCRIPTION
### 🔖  Issue Number

close https://github.com/boostcampwm-2024/iOS03-SniffMeet/issues/72

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] UserDefaults에서 프로필 데이터 가져오기
- [x] 프로필 전환할때 해당 데이터 표시하기

<img width="250" src="https://github.com/user-attachments/assets/7d6e2db8-b180-4ed5-b3f2-c7bb7350db80">
<img width="250" src="https://github.com/user-attachments/assets/6b876f03-cce5-4301-afd9-3ad114852a2d">

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1
Timer를 이용해 시간 지연을 주고 있어 무조건 시간 지연 발생 후 데이터가 교환됩니다.
때문에 그 사이에 ProfileDrop을 진행하면 제대로 동작하지 않습니다.
메서드 분리하고 호출하는 방식으로 변경했습니다.

- 특이 사항 2
........p2p 연결 문제를 해결했습니다...........
기존에 각 기기가 와이파이 연결 상태에서는 프로필 드랍이 잘 동작하지만
p2p 연결 상태에서는 잘 동작하지 않는 문제가 있었습니다.
결론은 권한 문제였습니다.
로컬 네트워크에 대한 권한이 사라져있어 그 결과 MPC 세션 연결이 끊기는 문제였습니다.
권한 추가 상태를 자주 확인합시다..^^!

### 👻 레퍼런스

