### PR TITLE
[feat] 서버에서 사용자 정보 가져오는 유즈케이스 구현

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		3200453F2CF5A8B800D08B6D /* CalculateTimeLimitUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200453E2CF5A88A00D08B6D /* CalculateTimeLimitUseCase.swift */; };
 		320047652CF6B86D00D08B6D /* RespondMateRequestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047642CF6B83B00D08B6D /* RespondMateRequestUseCase.swift */; };
 		320047832CF70CA300D08B6D /* PresentAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047822CF70C9E00D08B6D /* PresentAnimator.swift */; };
+		9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */; };
 		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
 		995D94622CE598FD005A47BF /* NIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94612CE598F0005A47BF /* NIManager.swift */; };
 		995D94A82CECEF91005A47BF /* RequestMateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94A72CECEF91005A47BF /* RequestMateViewController.swift */; };
@@ -67,7 +68,6 @@
 		A20E71502CEC595C00272B25 /* SupabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E714F2CEC595C00272B25 /* SupabaseError.swift */; };
 		A20E71522CEC5FE900272B25 /* SupabaseUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E71512CEC5FE900272B25 /* SupabaseUserResponse.swift */; };
 		A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21435F62CE20D2500564A4D /* TabBarController.swift */; };
-		A22040092CF6B12B00D1E8CB /* SupabaseDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A22040082CF6B12B00D1E8CB /* SupabaseDatabaseTests.swift */; };
 		A220400B2CF6B89800D1E8CB /* UserInfoDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A220400A2CF6B89800D1E8CB /* UserInfoDTO.swift */; };
 		A23A3B732CF4683F00A58705 /* Mate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23A3B722CF4683F00A58705 /* Mate.swift */; };
 		A24082612CEB244C009109A0 /* SupabaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24082602CEB244C009109A0 /* SupabaseConfig.swift */; };
@@ -266,6 +266,7 @@
 		3200453E2CF5A88A00D08B6D /* CalculateTimeLimitUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateTimeLimitUseCase.swift; sourceTree = "<group>"; };
 		320047642CF6B83B00D08B6D /* RespondMateRequestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RespondMateRequestUseCase.swift; sourceTree = "<group>"; };
 		320047822CF70C9E00D08B6D /* PresentAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentAnimator.swift; sourceTree = "<group>"; };
+		9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUserInfoRemoteUseCase.swift; sourceTree = "<group>"; };
 		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
 		995D94612CE598F0005A47BF /* NIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIManager.swift; sourceTree = "<group>"; };
 		995D94A72CECEF91005A47BF /* RequestMateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMateViewController.swift; sourceTree = "<group>"; };
@@ -279,7 +280,6 @@
 		A20E714F2CEC595C00272B25 /* SupabaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseError.swift; sourceTree = "<group>"; };
 		A20E71512CEC5FE900272B25 /* SupabaseUserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseUserResponse.swift; sourceTree = "<group>"; };
 		A21435F62CE20D2500564A4D /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
-		A22040082CF6B12B00D1E8CB /* SupabaseDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseDatabaseTests.swift; sourceTree = "<group>"; };
 		A220400A2CF6B89800D1E8CB /* UserInfoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoDTO.swift; sourceTree = "<group>"; };
 		A23A3B722CF4683F00A58705 /* Mate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mate.swift; sourceTree = "<group>"; };
 		A24082602CEB244C009109A0 /* SupabaseConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseConfig.swift; sourceTree = "<group>"; };
@@ -460,6 +460,7 @@
 				3200449B2CEDA86B00D08B6D /* RespondWalkRequestUseCase.swift */,
 				320047642CF6B83B00D08B6D /* RespondMateRequestUseCase.swift */,
 				320044992CEDA80400D08B6D /* RequestUserInfoUseCase.swift */,
+				9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */,
 				FD119F472CED872500BE22BD /* RequestLocationAuthUseCase.swift */,
 				FD119F492CED875800BE22BD /* RequestUserLocationUseCase.swift */,
 				320044762CEB4E0F00D08B6D /* RequestWalkUseCase.swift */,
@@ -1901,6 +1902,7 @@
 				320044942CED80B700D08B6D /* RespondWalkInteractor.swift in Sources */,
 				FD331A912CF3461B00F39426 /* NotificationListViewController.swift in Sources */,
 				FDE768922CF7828700B5DE88 /* AnyJSONSerializable.swift in Sources */,
+				9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */,
 				FD331A602CF339B000F39426 /* SupabaseStorageRequest.swift in Sources */,
 				320044892CEC862D00D08B6D /* LocationSelectionView.swift in Sources */,
 				FD331A4D2CF235A100F39426 /* SNMLineTabBar.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
@@ -15,20 +15,12 @@ protocol RemoteDatabaseManager {
     func updateData(into table: String, with data: Data) async throws
 }
 
-enum DatabaseState {
-    case fetchData
-    case insertData
-    case updateData
-}
-
 final class SupabaseDatabaseManager: RemoteDatabaseManager {
     static let shared: RemoteDatabaseManager = SupabaseDatabaseManager()
-    var databaseStateSubject: PassthroughSubject<DatabaseState, Never>
     private let networkProvider: SNMNetworkProvider
     private let decoder: JSONDecoder
 
     private init() {
-        databaseStateSubject = PassthroughSubject<DatabaseState, Never>()
         networkProvider = SNMNetworkProvider()
         decoder = JSONDecoder()
     }
@@ -46,7 +38,6 @@ final class SupabaseDatabaseManager: RemoteDatabaseManager {
                 accessToken: session.accessToken
             )
         )
-        databaseStateSubject.send(.fetchData)
         return response.data
     }
 
@@ -81,7 +72,6 @@ final class SupabaseDatabaseManager: RemoteDatabaseManager {
                 data: data
             )
         )
-        databaseStateSubject.send(.insertData)
     }
 
     func updateData(into table: String, with data: Data) async throws {
@@ -98,6 +88,5 @@ final class SupabaseDatabaseManager: RemoteDatabaseManager {
                 data: data
             )
         )
-        databaseStateSubject.send(.insertData)
     }
 }

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseRequest.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseRequest.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum SupabaseDatabaseRequest {
     case fetchData(table: String, accessToken: String)
+    case fetchDataWithID(table: String, id: UUID, accessToken: String)
     case insertData(table: String, accessToken: String, data: Data)
     case updateData(table: String, accessToken: String, data: Data)
 }
@@ -22,6 +23,13 @@ extension SupabaseDatabaseRequest: SNMRequestConvertible {
                 path: "rest/v1/\(table)",
                 method: .get,
                 query: nil
+            )
+        case .fetchDataWithID(let table, let id, _):
+            return Endpoint(
+                baseURL: SupabaseConfig.baseURL,
+                path: "rest/v1/\(table)",
+                method: .get,
+                query: ["id": "eq.\(id)"]
             )
         case .insertData(let table, _, _):
             return Endpoint(
@@ -46,6 +54,11 @@ extension SupabaseDatabaseRequest: SNMRequestConvertible {
         ]
         switch self {
         case .fetchData(_, let accessToken):
+            header["Authorization"] = "Bearer \(accessToken)"
+            return SNMRequestType.header(
+                with: header
+            )
+        case .fetchDataWithID(_, _, let accessToken):
             header["Authorization"] = "Bearer \(accessToken)"
             return SNMRequestType.header(
                 with: header

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUserInfoRemoteUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUserInfoRemoteUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  RequestUserInfoRemoteUseCase.swift
+//  SniffMeet
+//
+//  Created by 배현진 on 11/27/24.
+//
+
+import Foundation
+
+protocol RequestUserInfoRemoteUseCase {
+    func execute() async throws -> [UserInfo]
+}
+
+struct RequestUserInfoRemoteUseCaseImpl: RequestUserInfoRemoteUseCase {
+    func execute() async throws -> [UserInfo] {
+        guard let userID = SessionManager.shared.session?.user?.userID else {
+            throw SupabaseError.sessionNotExist
+        }
+        let data = try await SupabaseDatabaseManager.shared.fetchDataWithID(from: "user_info",
+                                                                            with: userID)
+        let decoder = JSONDecoder()
+        let info = try decoder.decode([UserInfo].self, from: data)
+        return info
+    }
+}

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUserInfoRemoteUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUserInfoRemoteUseCase.swift
@@ -8,18 +8,18 @@
 import Foundation
 
 protocol RequestUserInfoRemoteUseCase {
-    func execute() async throws -> [UserInfo]
+    func execute() async throws -> [UserInfoDTO]
 }
 
 struct RequestUserInfoRemoteUseCaseImpl: RequestUserInfoRemoteUseCase {
-    func execute() async throws -> [UserInfo] {
+    func execute() async throws -> [UserInfoDTO] {
         guard let userID = SessionManager.shared.session?.user?.userID else {
             throw SupabaseError.sessionNotExist
         }
         let data = try await SupabaseDatabaseManager.shared.fetchDataWithID(from: "user_info",
                                                                             with: userID)
         let decoder = JSONDecoder()
-        let info = try decoder.decode([UserInfo].self, from: data)
+        let info = try decoder.decode([UserInfoDTO].self, from: data)
         return info
     }
 }


### PR DESCRIPTION
### 🔖  Issue Number

close https://github.com/boostcampwm-2024/iOS03-SniffMeet/issues/115

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] RequestUserInfoRemoteUseCase 구현
- [x] SupabaseDatabaseManager 수정 - 필터링 추가
- [x] SupabaseDatabaseRequest 수정 - 필터링 추가


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1

테스트 코드를 따로 작성하지 않고, 뷰컨에 직접 추가하여 테스트한 후 해당 내용 삭제했습니다.
배열 형태로 값을 리턴하니, 사용하실 때 참고해주세요.

![Screenshot 2024-11-28 at 11 11 29 AM](https://github.com/user-attachments/assets/44984a09-153a-4080-b776-a936b28eeecd)

- 특이 사항 2

필터링 없이 query의 값이 nil 인 경우에도 해당 사용자에 대한 정보만 가져와지는 부분 확인을 위해 테스트 진행했습니다.
기존에 만들어져있던 featchData()를 그대로 사용해보았고 그 결과 아래 로그처럼 전체 사용자 목록 전부를 가져오는것을 확인했습니다. 

![Screenshot 2024-11-28 at 11 21 37 AM](https://github.com/user-attachments/assets/0aeb45e4-3fec-470c-af16-2203c4108dab)

쿼리에 필터링 요소가 필요함을 확인했고, fetchDataWithID() 함수로 만들어 사용했습니다.
이후 필요하신 경우 자유롭게 추가함수 만들어 필터링 거시면 될 것 같습니다.
필터링은 ["id": "eq.\(id)"] 형태로 쿼리를 만들어 사용하실 수 있습니다. 
해당 내용은 "id"에 해당하는 데이터의 값이 저희가 지정한 id와 같은 경우 해당 레코드의 모든 열을 가져오는 조건입니다.
즉, id가 지정한 값과 동일한 경우 그 id를 포함한 "user_info" 테이블의 모든 데이터를 가져옵니다.
조건을 변경하고 싶다면 eq.를 사용해 조건을 추가하면되고,
조건을 만족할 경우 특정 데이터만 가져오고 싶다면 select를 활용해 쿼리에 조건을 추가하면 됩니다.


### 👻 레퍼런스
- [Supabase Filters](https://supabase.com/docs/reference/swift/using-filters)

