### PR TITLE
[fix] 유저 정보 저장 및 로드 에러 수정 

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		3200453F2CF5A8B800D08B6D /* CalculateTimeLimitUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200453E2CF5A88A00D08B6D /* CalculateTimeLimitUseCase.swift */; };
 		320047652CF6B86D00D08B6D /* RespondMateRequestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047642CF6B83B00D08B6D /* RespondMateRequestUseCase.swift */; };
 		320047832CF70CA300D08B6D /* PresentAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047822CF70C9E00D08B6D /* PresentAnimator.swift */; };
+		320047852CF80B2600D08B6D /* MateList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047842CF80B2200D08B6D /* MateList.swift */; };
 		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
 		995D94622CE598FD005A47BF /* NIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94612CE598F0005A47BF /* NIManager.swift */; };
 		995D94A82CECEF91005A47BF /* RequestMateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94A72CECEF91005A47BF /* RequestMateViewController.swift */; };
@@ -67,7 +68,6 @@
 		A20E71502CEC595C00272B25 /* SupabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E714F2CEC595C00272B25 /* SupabaseError.swift */; };
 		A20E71522CEC5FE900272B25 /* SupabaseUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E71512CEC5FE900272B25 /* SupabaseUserResponse.swift */; };
 		A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21435F62CE20D2500564A4D /* TabBarController.swift */; };
-		A22040092CF6B12B00D1E8CB /* SupabaseDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A22040082CF6B12B00D1E8CB /* SupabaseDatabaseTests.swift */; };
 		A220400B2CF6B89800D1E8CB /* UserInfoDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A220400A2CF6B89800D1E8CB /* UserInfoDTO.swift */; };
 		A23A3B732CF4683F00A58705 /* Mate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23A3B722CF4683F00A58705 /* Mate.swift */; };
 		A24082612CEB244C009109A0 /* SupabaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24082602CEB244C009109A0 /* SupabaseConfig.swift */; };
@@ -266,6 +266,7 @@
 		3200453E2CF5A88A00D08B6D /* CalculateTimeLimitUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateTimeLimitUseCase.swift; sourceTree = "<group>"; };
 		320047642CF6B83B00D08B6D /* RespondMateRequestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RespondMateRequestUseCase.swift; sourceTree = "<group>"; };
 		320047822CF70C9E00D08B6D /* PresentAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentAnimator.swift; sourceTree = "<group>"; };
+		320047842CF80B2200D08B6D /* MateList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateList.swift; sourceTree = "<group>"; };
 		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
 		995D94612CE598F0005A47BF /* NIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIManager.swift; sourceTree = "<group>"; };
 		995D94A72CECEF91005A47BF /* RequestMateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMateViewController.swift; sourceTree = "<group>"; };
@@ -279,7 +280,6 @@
 		A20E714F2CEC595C00272B25 /* SupabaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseError.swift; sourceTree = "<group>"; };
 		A20E71512CEC5FE900272B25 /* SupabaseUserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseUserResponse.swift; sourceTree = "<group>"; };
 		A21435F62CE20D2500564A4D /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
-		A22040082CF6B12B00D1E8CB /* SupabaseDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseDatabaseTests.swift; sourceTree = "<group>"; };
 		A220400A2CF6B89800D1E8CB /* UserInfoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoDTO.swift; sourceTree = "<group>"; };
 		A23A3B722CF4683F00A58705 /* Mate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mate.swift; sourceTree = "<group>"; };
 		A24082602CEB244C009109A0 /* SupabaseConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseConfig.swift; sourceTree = "<group>"; };
@@ -610,6 +610,7 @@
 		A2BD49F02CF72A8800AC72A7 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				320047842CF80B2200D08B6D /* MateList.swift */,
 				995D94D12CEDF031005A47BF /* MPCProfileDropDTO.swift */,
 				A2BD49F52CF72B4000AC72A7 /* WalkNotiDTO.swift */,
 				A2BD49F12CF72A9500AC72A7 /* DogProfileDTO.swift */,
@@ -1807,6 +1808,7 @@
 				A25BE4582CEBB95C00886763 /* SupabaseRefreshResponse.swift in Sources */,
 				FDEAEA7C2CE314A7005890FA /* BaseViewController.swift in Sources */,
 				FDE768A12CF7873600B5DE88 /* RequestNotificationAuthUseCase.swift in Sources */,
+				320047852CF80B2600D08B6D /* MateList.swift in Sources */,
 				A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */,
 				320043762CDCA18E00D08B6D /* (null) in Sources */,
 				995D94D22CEDF037005A47BF /* MPCProfileDropDTO.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Interactor/ProfileCreateInteractor.swift
@@ -5,7 +5,6 @@
 //  Created by 윤지성 on 11/14/24.
 //
 
-import Foundation
 import UIKit
 
 protocol ProfileCreateInteractable: AnyObject {
@@ -13,7 +12,7 @@ protocol ProfileCreateInteractable: AnyObject {
     var saveUserInfoUseCase: SaveUserInfoUseCase { get set }
     var saveProfileImageUseCase: SaveProfileImageUseCase { get }
 
-    func signInWithProfileData(dogInfo: UserInfo)
+    func signInWithProfileData(dogInfo: UserInfo, imageData: Data?)
     func convertImageToData(image: UIImage?) -> Data?
 }
 
@@ -35,15 +34,22 @@ final class ProfileCreateInteractor: ProfileCreateInteractable {
         self.saveUserInfoRemoteUseCase = saveUserInfoRemoteUseCase
     }
 
-    func signInWithProfileData(dogInfo: UserInfo) {
+    func signInWithProfileData(dogInfo: UserInfo, imageData: Data?) {
         Task {
             do {
                 await SupabaseAuthManager.shared.signInAnonymously()
-                try saveUserInfoUseCase.execute(dog: dogInfo)
+                try saveUserInfoUseCase.execute(dog: UserInfo(name: dogInfo.name,
+                                                              age: dogInfo.age,
+                                                              sex: dogInfo.sex,
+                                                              sexUponIntake: dogInfo.sexUponIntake,
+                                                              size: dogInfo.size,
+                                                              keywords: dogInfo.keywords,
+                                                              nickname: dogInfo.nickname,
+                                                              profileImage: imageData))
                 var fileName: String? = nil
-                if let profileImageData = dogInfo.profileImage {
+                if let imageData {
                     fileName = try await saveProfileImageUseCase.execute(
-                        imageData: profileImageData
+                        imageData: imageData
                     )
                 }
                 guard let userID = SessionManager.shared.session?.user?.userID else {

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
@@ -41,14 +41,6 @@ final class ProfileCreatePresenter: ProfileCreatePresentable {
 
     func didTapSubmitButton(nickname: String, image: UIImage?) {
         let imageData = interactor?.convertImageToData(image: image)
-//        let dogInfo = Dog(name: dogInfo.name,
-//                      age: dogInfo.age,
-//                      sex: dogInfo.sex,
-//                      sexUponIntake: dogInfo.sexUponIntake,
-//                      size: dogInfo.size,
-//                      keywords: dogInfo.keywords,
-//                      nickname: nickname,
-//                      profileImage: imageData)
         let userInfo = UserInfo(
             name: dogInfo.name,
             age: dogInfo.age,
@@ -60,7 +52,7 @@ final class ProfileCreatePresenter: ProfileCreatePresentable {
             profileImage: nil
         )
         // TODO: SubmitButton disable 필요
-        interactor?.signInWithProfileData(dogInfo: userInfo)
+        interactor?.signInWithProfileData(dogInfo: userInfo, imageData: imageData)
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Router/ProfileCreateRouter.swift
@@ -31,7 +31,10 @@ final class ProfileCreateRouter: ProfileCreateRoutable {
 extension ProfileCreateRouter: ProfileCreateBuildable {
     static func createProfileCreateModule(dogDetailInfo: DogInfo) -> UIViewController {
         let saveUserInfoUseCase: SaveUserInfoUseCase =
-        SaveUserInfoUseCaseImpl(localDataManager: LocalDataManager())
+        SaveUserInfoUseCaseImpl(
+            localDataManager: LocalDataManager(),
+            imageManager: SNMFileManager()
+        )
         let saveProfileImageUseCase: SaveProfileImageUseCase =
         SaveProfileImageUseCaseImpl(
             remoteImageManager: SupabaseStorageManager(

--- a/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
@@ -10,11 +10,23 @@ enum Environment {
         static let profileImage: String = "profileImage"
         static let dogInfo: String = "dogInfo"
         static let expiresAt: String = "expiresAt"
+        static let mateList: String = "mateList"
     }
 
     enum KeychainKey {
         static let accessToken: String = "accessToken"
         static let refreshToken: String = "refreshToken"
         static let deviceToken: String = "deviceToken"
+    }
+    
+    enum FileManagerKey {
+        static let profileImage: String = "profile"
+    }
+    
+    enum SupabaseTableName {
+        static let userInfo = "user_info"
+        static let notification = "notification"
+        static let notification_list = "notification_list"
+        static let matelist = "mate_list"
     }
 }

--- a/SniffMeet/SniffMeet/Source/DTO/MateList.swift
+++ b/SniffMeet/SniffMeet/Source/DTO/MateList.swift
@@ -1,0 +1,16 @@
+//
+//  MateList.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 11/28/24.
+//
+import Foundation
+
+struct MateListDTO: Encodable {
+    let id: UUID
+    let mates: [UUID]
+}
+
+struct MateListResponseDTO: Decodable {
+    let mates: [UserInfo]
+}

--- a/SniffMeet/SniffMeet/Source/Entity/UserInfo.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/UserInfo.swift
@@ -23,7 +23,7 @@ struct UserInfo: Codable {
     let size: Size
     let keywords: [Keyword]
     let nickname: String
-    let profileImage: Data?
+    var profileImage: Data?
 }
 
 extension UserInfo {

--- a/SniffMeet/SniffMeet/Source/Home/Main/HomeModuleBuilder.swift
+++ b/SniffMeet/SniffMeet/Source/Home/Main/HomeModuleBuilder.swift
@@ -13,7 +13,8 @@ enum HomeModuleBuilder {
         let router = HomeRouter()
         let interactor = HomeInteractor(
             loadUserInfoUseCase: LoadUserInfoUseCaseImpl(
-                dataLoadable: LocalDataManager()
+                dataLoadable: LocalDataManager(),
+                imageManageable: SNMFileManager()
             )
         )
         view.presenter = HomePresenter(view: view, router: router, interactor: interactor)

--- a/SniffMeet/SniffMeet/Source/Persistence/SNMFileManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/SNMFileManager.swift
@@ -4,11 +4,11 @@
 //
 //  Created by 윤지성 on 11/25/24.
 //
-import UIKit
+import Foundation
 
 protocol ImageManagable {
-    func get(forKey: String) throws -> UIImage?
-    func set(image: UIImage, forKey: String) throws
+    func get(forKey: String) throws -> Data?
+    func set(imageData: Data, forKey: String) throws
     func delete(forKey: String) throws
 }
 
@@ -19,7 +19,7 @@ struct SNMFileManager: ImageManagable {
     }
     
     func fileExists(forKey path: String) -> Bool {
-        guard let documentsDir else { return false}
+        guard let documentsDir else { return false }
         let fileURL = documentsDir.appendingPathComponent(path, conformingTo: .png)
         if #available(iOS 16.0, *) {
             return fileManager.fileExists(atPath: fileURL.path())
@@ -28,7 +28,8 @@ struct SNMFileManager: ImageManagable {
         }
     }
     
-    func get(forKey: String) throws -> UIImage? {
+    /// key 값은 Environment.FileManagerKey를 이용하시면 됩니다.
+    func get(forKey: String) throws -> Data? {
         guard let documentsDir else {
             throw FileManagerError.directoryNotFound
         }
@@ -36,19 +37,15 @@ struct SNMFileManager: ImageManagable {
         guard fileManager.fileExists(atPath: fileURL.path) else {
             throw FileManagerError.fileNotFound
         }
-        return UIImage(contentsOfFile: fileURL.path)
+        return try? Data(contentsOf: fileURL)
     }
     
-    func set(image: UIImage, forKey: String) throws {
+    func set(imageData: Data, forKey: String) throws {
         guard let documentsDir else {
             throw FileManagerError.directoryNotFound
         }
         /// key 값을 받아 해당 키 값이 파일 이름인 파일을 생성한다.
         let fileURL = documentsDir.appendingPathComponent(forKey, conformingTo: .png)
-        
-        guard let imageData = image.pngData() else {
-            throw FileManagerError.dataConversionError
-        }
         do {
             try imageData.write(to: fileURL)
         } catch {

--- a/SniffMeet/SniffMeet/Source/Repository/Auth/DataManager.swift
+++ b/SniffMeet/SniffMeet/Source/Repository/Auth/DataManager.swift
@@ -32,9 +32,3 @@ extension LocalDataManager: DataLoadable {
         try dataManager.get(forKey: forKey, type: type)
     }
 }
-
-
-enum UserDefaultKey {
-    static let userInfo: String = "userInfo"
-    static let mateList: String = "mateList"
-}

--- a/SniffMeet/SniffMeet/Source/Supabase/Auth/SupabaseAuthManager.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Auth/SupabaseAuthManager.swift
@@ -102,6 +102,6 @@ final class SupabaseAuthManager: AuthManager {
         try KeychainManager.shared.set(value: session.accessToken, forKey: "accessToken")
         try KeychainManager.shared.set(value: session.refreshToken, forKey: "refreshToken")
         try UserDefaultsManager.shared.set(value: session.expiresAt, forKey: "expiresAt")
-        try UserDefaultsManager.shared.set(value: session.user, forKey: "user")
+        try UserDefaultsManager.shared.set(value: session.user, forKey: Environment.UserDefaultsKey.dogInfo)
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/LoadUserInfoUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/LoadUserInfoUseCase.swift
@@ -11,12 +11,21 @@ protocol LoadUserInfoUseCase {
 
 struct LoadUserInfoUseCaseImpl: LoadUserInfoUseCase {
     private let dataLoadable: (any DataLoadable)
+    private let imageManageable: (any ImageManagable)
 
-    init(dataLoadable: any DataLoadable) {
+    init(dataLoadable: any DataLoadable, imageManageable: any ImageManagable) {
         self.dataLoadable = dataLoadable
+        self.imageManageable = imageManageable
     }
 
     func execute() throws -> UserInfo {
-        try dataLoadable.loadData(forKey: "dogInfo", type: UserInfo.self)
+        var userInfo = try dataLoadable.loadData(forKey: Environment.UserDefaultsKey.dogInfo,
+                                                 type: UserInfo.self)
+        do {
+            userInfo.profileImage = try imageManageable.get(forKey: Environment.FileManagerKey.profileImage)
+            return userInfo
+        } catch {
+            return userInfo
+        }
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/RespondMateRequestUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RespondMateRequestUseCase.swift
@@ -20,14 +20,14 @@ struct RespondMateRequestUseCaseImpl: RespondMateRequestUseCase {
         }
     }
     func addMate(mateId: UUID) {
-        var mateList: [UUID]? = try? localDataManager.loadData(forKey: UserDefaultKey.mateList, type: [UUID].self)
+        var mateList: [UUID]? = try? localDataManager.loadData(forKey: Environment.UserDefaultsKey.mateList, type: [UUID].self)
         
         do {
             if var mateList {
                 mateList.append(mateId)
-                try localDataManager.storeData(data: mateList, key: UserDefaultKey.mateList)
+                try localDataManager.storeData(data: mateList, key: Environment.UserDefaultsKey.mateList)
             } else {
-                try localDataManager.storeData(data: [mateId], key: UserDefaultKey.mateList)
+                try localDataManager.storeData(data: [mateId], key: Environment.UserDefaultsKey.mateList)
             }
         } catch {
             SNMLogger.error("AcceptMateRequestUsecaseError: \(error.localizedDescription)")

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUserInfoRemoteUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUserInfoRemoteUseCase.swift
@@ -19,11 +19,11 @@ struct SaveUserInfoRemoteUseCaseImpl: SaveUserInfoRemoteUseCase {
             let userData = try encoder.encode(info)
             let mateListData = try encoder.encode(MateListDTO(id: info.id, mates: []))
             try await SupabaseDatabaseManager.shared.insertData(
-                into: "user_info",
+                into: Environment.SupabaseTableName.userInfo,
                 with: userData
             )
             try await SupabaseDatabaseManager.shared.insertData(
-                into: "mate_list",
+                into: Environment.SupabaseTableName.matelist,
                 with: mateListData
             )
         } catch {

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUserInfoRemoteUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUserInfoRemoteUseCase.swift
@@ -17,9 +17,14 @@ struct SaveUserInfoRemoteUseCaseImpl: SaveUserInfoRemoteUseCase {
         let encoder = JSONEncoder()
         do {
             let userData = try encoder.encode(info)
+            let mateListData = try encoder.encode(MateListDTO(id: info.id, mates: []))
             try await SupabaseDatabaseManager.shared.insertData(
                 into: "user_info",
                 with: userData
+            )
+            try await SupabaseDatabaseManager.shared.insertData(
+                into: "mate_list",
+                with: mateListData
             )
         } catch {
             SNMLogger.error("\(error.localizedDescription)")

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUserInfoUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUserInfoUseCase.swift
@@ -12,8 +12,11 @@ protocol SaveUserInfoUseCase {
 
 struct SaveUserInfoUseCaseImpl: SaveUserInfoUseCase {
     let localDataManager: DataStorable
+    let imageManager: ImageManagable
     
     func execute(dog: UserInfo) throws {
-        try localDataManager.storeData(data: dog, key: UserDefaultKey.userInfo)
+        try localDataManager.storeData(data: dog, key: Environment.UserDefaultsKey.dogInfo)
+        guard let imageData = dog.profileImage else { return }
+        try imageManager.set(imageData: imageData, forKey: Environment.FileManagerKey.profileImage)
     }
 }


### PR DESCRIPTION
### 🔖  Issue Number

close #117

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  Userdefault key  값 수정 
- [x]  SupabaseTableName, FileMangerKey 네임스페이스 작성
- [x]  SaveUserInfo, LoadUserInfo 유즈케이스에 프로필 이미지를 FileManager 이용해서 저장하고 로드하는 로직 추가 
- [x] 정보 저장 Presenter, Interactor에서 프로필 이미지를 주고받는 것으로 수정 

이젠 잘 동작합니당 👍

<img width="240" alt="스크린샷 2024-11-07 오후 3 18 08" src="https://github.com/user-attachments/assets/206cc2b9-9979-4f54-b286-5ae5d6fe7fc9">


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1
다른 작업 하다가 에러를 고치게 되어서... PR과 무관한 커밋이 몇개 포함되어 있습니다. 다음부턴 주의하겠습니다! 
