### PR TITLE
[feat] 서버에서 프로필 이미지 가져와 표시하기

### DIFF
--- a/SniffMeet/SniffMeet/Source/DTO/MateList.swift
+++ b/SniffMeet/SniffMeet/Source/DTO/MateList.swift
@@ -10,7 +10,7 @@ import Foundation
 /// 처음 회원가입할 때는 메이트가 없으므로 빈 배열로 고정했습니다.
 struct MateListInsertDTO: Encodable {
     let id: UUID
-    let mates: [UUID] = []
+    let mates: [UUID] = [UUID(uuidString: "23f52fdb-5292-4afb-a8a4-6adb467b39ce") ?? .init()]
     enum CodingKeys: String, CodingKey {
         case id, mates
     }

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
@@ -18,6 +18,7 @@ final class MateListInteractor: MateListInteractable {
     weak var presenter: (any MateListInteractorOutput)?
     private let requestMateListUseCase: any RequestMateListUseCase
     private let requestProfileImageUseCase: any RequestProfileImageUseCase
+    private var mateList = [Mate]()
 
     init(
         presenter: (any MateListInteractorOutput)? = nil,
@@ -32,14 +33,15 @@ final class MateListInteractor: MateListInteractable {
 
     func requestMateList(userID: UUID) {
         Task { @MainActor in
-            let mateList = await requestMateListUseCase.execute()
+            mateList = await requestMateListUseCase.execute()
             presenter?.didFetchMateList(mateList: mateList)
         }
     }
 
     func requestProfileImage(index: Int, urlString: String?) {
         Task { @MainActor in
-            let imageData = await requestProfileImageUseCase.execute()
+            let fileName = mateList[index].profileImageURLString
+            let imageData = try await requestProfileImageUseCase.execute(fileName: fileName ?? "")
             presenter?.didFetchProfileImage(index: index, imageData: imageData)
         }
     }

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
@@ -11,15 +11,13 @@ protocol MateListInteractable: AnyObject {
     var presenter: MateListInteractorOutput? { get set }
 
     func requestMateList(userID: UUID)
-    func requestProfileImage(index: Int, urlString: String?)
+    func requestProfileImage(index: Int, imageName: String?)
 }
 
 final class MateListInteractor: MateListInteractable {
     weak var presenter: (any MateListInteractorOutput)?
     private let requestMateListUseCase: any RequestMateListUseCase
     private let requestProfileImageUseCase: any RequestProfileImageUseCase
-    private var mateList = [Mate]()
-
     init(
         presenter: (any MateListInteractorOutput)? = nil,
         requestMateListUseCase: any RequestMateListUseCase,
@@ -33,15 +31,14 @@ final class MateListInteractor: MateListInteractable {
 
     func requestMateList(userID: UUID) {
         Task { @MainActor in
-            mateList = await requestMateListUseCase.execute()
+            let mateList = await requestMateListUseCase.execute()
             presenter?.didFetchMateList(mateList: mateList)
         }
     }
 
-    func requestProfileImage(index: Int, urlString: String?) {
+    func requestProfileImage(index: Int, imageName: String?) {
         Task { @MainActor in
-            let fileName = mateList[index].profileImageURLString
-            let imageData = try await requestProfileImageUseCase.execute(fileName: fileName ?? "")
+            let imageData = try await requestProfileImageUseCase.execute(fileName: imageName ?? "")
             presenter?.didFetchProfileImage(index: index, imageData: imageData)
         }
     }

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Presenter/MateListPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Presenter/MateListPresenter.swift
@@ -15,7 +15,7 @@ protocol MateListPresentable: AnyObject {
     var output: any MateListPresenterOutput { get }
     
     func viewDidLoad()
-    func didTableViewCellLoad(index: Int, urlString: String?)
+    func didTableViewCellLoad(index: Int, imageName: String?)
     func didTabAccessoryButton(mate: Mate)
 }
 
@@ -25,6 +25,7 @@ protocol MateListInteractorOutput: AnyObject {
 }
 
 final class MateListPresenter: MateListPresentable {
+    
     weak var view: (any MateListViewable)?
     var interactor: (any MateListInteractable)?
     var router: (any MateListRoutable)?
@@ -48,8 +49,8 @@ final class MateListPresenter: MateListPresentable {
         interactor?.requestMateList(userID: userID)
     }
 
-    func didTableViewCellLoad(index: Int, urlString: String?) {
-        interactor?.requestProfileImage(index: index, urlString: urlString)
+    func didTableViewCellLoad(index: Int, imageName: String?) {
+        interactor?.requestProfileImage(index: index, imageName: imageName)
     }
 
     func didTabAccessoryButton(mate: Mate) {

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
@@ -27,9 +27,11 @@ struct MateListRouter: MateListRoutable {
 
 extension MateListRouter: MateListBuildable {
     static func createMateListModule() -> UIViewController {
-        let requestMateListUseCase: RequestMateListUseCase = RequestMateListUseCaseImpl(remoteDatabaseManager: SupabaseDatabaseManager.shared)
-        let requestProfileImageUseCase: RequestProfileImageUseCase = RequestProfileImageUseCaseImpl()
-
+        let requestMateListUseCase: RequestMateListUseCase = RequestMateListUseCaseImpl(
+            remoteDatabaseManager: SupabaseDatabaseManager.shared)
+        let requestProfileImageUseCase: RequestProfileImageUseCase = RequestProfileImageUseCaseImpl(
+            remoteImageManager: SupabaseStorageManager(
+            networkProvider: SNMNetworkProvider()))
         let view: MateListViewable & UIViewController = MateListViewController()
         let presenter: MateListPresentable & MateListInteractorOutput =
         MateListPresenter()

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
@@ -14,7 +14,6 @@ protocol MateListViewable: AnyObject {
 
 final class MateListViewController: BaseViewController, MateListViewable {
     var presenter: (any MateListPresentable)?
-    var dataSource: [Mate] = []
     var imageDataSource: [Int: Data] = [:]
     private var cancellables: Set<AnyCancellable> = []
     private let tableView: UITableView = UITableView()
@@ -56,7 +55,6 @@ final class MateListViewController: BaseViewController, MateListViewable {
         presenter?.output.mates
             .receive(on: RunLoop.main)
             .sink { [weak self] mates in
-                self?.dataSource = mates
                 self?.tableView.reloadData()
             }
             .store(in: &cancellables)
@@ -82,7 +80,7 @@ final class MateListViewController: BaseViewController, MateListViewable {
 
 extension MateListViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        dataSource.count
+        presenter?.output.mates.value.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -94,19 +92,22 @@ extension MateListViewController: UITableViewDelegate, UITableViewDataSource {
         content.image = .app
         if let imageData = imageDataSource[indexPath.row] {
             var profileImage = UIImage(data: imageData)
-            profileImage = profileImage?.clipToSquareWithBackgroundColor(with: ItemSize.profileImageSize.width)
+            profileImage = profileImage?.clipToSquareWithBackgroundColor(
+                with: ItemSize.profileImageSize.width)
             content.image = profileImage
         } else {
             presenter?.didTableViewCellLoad(
                 index: indexPath.row,
-                urlString: dataSource[indexPath.row].profileImageURLString
+                imageName: presenter?.output.mates.value[indexPath.row].profileImageURLString
             )
         }
         content.imageProperties.maximumSize = ItemSize.profileImageSize
         content.imageProperties.cornerRadius = ItemSize.profileImageCornerRadius
-        content.text = dataSource[indexPath.row].name
+        content.text = presenter?.output.mates.value[indexPath.row].name
         cell.contentConfiguration = content
-        cell.accessoryView = createAccessoryButton(mate: dataSource[indexPath.row])
+        if let mate = presenter?.output.mates.value[indexPath.row] {
+            cell.accessoryView = createAccessoryButton(mate: mate)
+        }
         cell.selectionStyle = .none
         return cell
     }

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
@@ -10,7 +10,6 @@ import Foundation
 
 protocol RemoteDatabaseManager {
     func fetchData(from table: String, query: [String: String]) async throws -> Data
-    func fetchDataWithID(from table: String, with id: UUID) async throws -> Data
     func insertData(into table: String, with data: Data) async throws
     func updateData(into table: String, with data: Data) async throws
     func fetchUserInfoFromMateList() async throws -> Data
@@ -38,23 +37,6 @@ final class SupabaseDatabaseManager: RemoteDatabaseManager {
                 table: table,
                 accessToken: session.accessToken,
                 query: query
-            )
-        )
-        return response.data
-    }
-
-    func fetchDataWithID(from table: String, with id: UUID) async throws -> Data {
-        if SessionManager.shared.isExpired {
-            try await SupabaseAuthManager.shared.refreshSession()
-        }
-        guard let session = SessionManager.shared.session else {
-            throw SupabaseError.sessionNotExist
-        }
-        let response = try await networkProvider.request(
-            with: SupabaseDatabaseRequest.fetchDataWithID(
-                table: table,
-                id: id,
-                accessToken: session.accessToken
             )
         )
         return response.data

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseRequest.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseRequest.swift
@@ -9,7 +9,6 @@ import Foundation
 
 enum SupabaseDatabaseRequest {
     case fetchData(table: String, accessToken: String, query: [String: String])
-    case fetchDataWithID(table: String, id: UUID, accessToken: String)
     case insertData(table: String, accessToken: String, data: Data)
     case updateData(table: String, id: UUID, accessToken: String, data: Data)
     case fetchUserInfoFromMateList(data: Data, accessToken: String)
@@ -24,13 +23,6 @@ extension SupabaseDatabaseRequest: SNMRequestConvertible {
                 path: "rest/v1/\(table)",
                 method: .get,
                 query: query
-            )
-        case .fetchDataWithID(let table, let id, _):
-            return Endpoint(
-                baseURL: SupabaseConfig.baseURL,
-                path: "rest/v1/\(table)",
-                method: .get,
-                query: ["id": "eq.\(id)"]
             )
         case .insertData(let table, _, _):
             return Endpoint(
@@ -62,11 +54,6 @@ extension SupabaseDatabaseRequest: SNMRequestConvertible {
         ]
         switch self {
         case .fetchData(_, let accessToken, _):
-            header["Authorization"] = "Bearer \(accessToken)"
-            return SNMRequestType.header(
-                with: header
-            )
-        case .fetchDataWithID(_, _, let accessToken):
             header["Authorization"] = "Bearer \(accessToken)"
             return SNMRequestType.header(
                 with: header

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestMateInfoUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestMateInfoUseCase.swift
@@ -16,7 +16,7 @@ struct RequestMateInfoUsecaseImpl: RequestMateInfoUseCase {
     func execute(mateId: UUID) async -> UserInfoDTO? {
         do {
             let mateInfoData = try await SupabaseDatabaseManager.shared.fetchData(
-                from: "user_info",
+                from: Environment.SupabaseTableName.userInfo,
                 query: ["id": "eq.\(mateId.uuidString)"]
             )
             let mateInfo = try JSONDecoder().decode(UserInfoDTO.self, from: mateInfoData)

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
@@ -8,11 +8,20 @@
 import Foundation
 
 protocol RequestProfileImageUseCase {
-    func execute() async -> Data?
+    func execute(fileName: String) async throws -> Data?
 }
 
 struct RequestProfileImageUseCaseImpl: RequestProfileImageUseCase {
-    func execute() async -> Data? {
-        return nil
+    private let remoteImageManager: any RemoteImageManagable
+
+    init(
+        remoteImageManager: any RemoteImageManagable
+    ) {
+        self.remoteImageManager = remoteImageManager
+    }
+
+    func execute(fileName: String) async throws -> Data? {
+        let data = try await remoteImageManager.download(fileName: fileName)
+        return data
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestUserInfoRemoteUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestUserInfoRemoteUseCase.swift
@@ -16,8 +16,9 @@ struct RequestUserInfoRemoteUseCaseImpl: RequestUserInfoRemoteUseCase {
         guard let userID = SessionManager.shared.session?.user?.userID else {
             throw SupabaseError.sessionNotExist
         }
-        let data = try await SupabaseDatabaseManager.shared.fetchDataWithID(from: "user_info",
-                                                                            with: userID)
+        let data = try await SupabaseDatabaseManager.shared.fetchData(
+            from: Environment.SupabaseTableName.userInfo,
+            query: ["id": "eq.\(userID)"])
         let decoder = JSONDecoder()
         let info = try decoder.decode([UserInfoDTO].self, from: data)
         return info

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Interactor/RequestWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Interactor/RequestWalkInteractor.swift
@@ -45,7 +45,8 @@ final class RequestWalkInteractor: RequestWalkInteractable {
 
     func requestProfileImage(imageName: String?) {
         Task { @MainActor in
-            let imageData = await requestProfileImageUseCase.execute()
+            let fileName = mate.profileImageURLString ?? ""
+            let imageData = try await requestProfileImageUseCase.execute(fileName: fileName)
             presenter?.didFetchProfileImage(imageData: imageData)
         }
     }

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Router/RequestWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Router/RequestWalkRouter.swift
@@ -42,7 +42,9 @@ extension RequestWalkRouter: RequestWalkBuildable {
     static func createRequestWalkModule(mate: Mate) -> UIViewController {
         let requestWalkUseCase: RequestWalkUseCase = RequestWalkUseCaseImpl()
         let requestProfileImageUseCase:
-        RequestProfileImageUseCase = RequestProfileImageUseCaseImpl()
+        RequestProfileImageUseCase = RequestProfileImageUseCaseImpl(
+            remoteImageManager: SupabaseStorageManager(
+            networkProvider: SNMNetworkProvider()))
         let view: RequestWalkViewable & UIViewController = RequestWalkViewController()
         let presenter: RequestWalkPresentable & RequestWalkInteractorOutput = RequestWalkPresenter()
         let interactor: RequestWalkInteractable = RequestWalkInteractor(

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Interactor/RespondWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Interactor/RespondWalkInteractor.swift
@@ -85,7 +85,9 @@ final class RespondWalkInteractor: RespondWalkInteractable {
     
     func fetchProfileImage() {
         Task { [weak self] in
-            let imageData = await requestProfileImageUseCase.execute()
+            // fileName = senderInfo.profileImageURL 사용해 이미지 이름 가져오기
+            let fileName = ""
+            let imageData = try await requestProfileImageUseCase.execute(fileName: fileName)
             self?.presenter?.didFetchProfileImage(with: imageData)
         }
     }

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/RespondWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/RespondWalkRouter.swift
@@ -30,7 +30,9 @@ extension RespondWalkRouter: RespondWalkBuildable {
         let convertLocationToTextUseCase: ConvertLocationToTextUseCase =
         ConvertLocationToTextUseCaseImpl(geoCoder: CLGeocoder())
         let requestProfileImageUseCase: RequestProfileImageUseCase =
-        RequestProfileImageUseCaseImpl()
+        RequestProfileImageUseCaseImpl(
+            remoteImageManager: SupabaseStorageManager(
+            networkProvider: SNMNetworkProvider()))
 
         let view: RespondWalkViewable & UIViewController = RespondWalkViewController()
         let presenter: RespondWalkPresentable & RespondWalkInteractorOutput =


### PR DESCRIPTION
### 🔖  Issue Number

close #121

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] 서버에서 이미지 가져오는 유즈케이스 작성
- [x] 메이트 목록에 이미지 표시하기
- [x] 산책 요청시에 이미지 표시하기

<img width="250" src="https://github.com/user-attachments/assets/1e705ad0-be18-470a-b52d-50b5b39de2c7">
<img width="250" src="https://github.com/user-attachments/assets/945e89c5-a62a-46f4-8b51-064570c6735d">

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1
현재 산책 요청 받는 부분에서는 화면을 확인할 수 없어 어떻게 구현해야하는지 표시만 하고 주석처리 해두었습니다.
주석 처리 부분을 이용해 fileName 가져오고 그에 해당하는 이미지 서버에서 가져오면 됩니다.
```swift
    // fileName = senderInfo.profileImageURL 사용해 이미지 이름 가져오기
    let fileName = ""
     let imageData = try await requestProfileImageUseCase.execute(fileName: fileName)
    self?.presenter?.didFetchProfileImage(with: imageData)
```

- 특이 사항 2
혹시 메이트가 아닌 자신의 프로필 이미지를 '서버'에서 가져오고 싶다면 아래처럼 이용하시면 됩니다.
대부분 로컬에서 가져오기 때문에 사용할 일은 별로 없을 것 같습니다.
```swift
let userInfo = try await RequestUserInfoRemoteUseCaseImpl().execute()
let fileName = userInfo.first?.profileImageURL
```

- 특이 사항 3
배포 시점에 추가했던 로그인 시점에 기본 메이트 추가하는 내용 해당 브랜치로 옮겼습니다.
'후추' 프로필이 기본 메이트로 생성됩니다.


### 👻 레퍼런스
