### PR TITLE
[fix] 메이트 리스트 목록 갱신 문제 해결

### DIFF
--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Presenter/MateListPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Presenter/MateListPresenter.swift
@@ -14,7 +14,7 @@ protocol MateListPresentable: AnyObject {
     var interactor: (any MateListInteractable)? { get set }
     var output: any MateListPresenterOutput { get }
     
-    func viewDidLoad()
+    func viewWillAppear()
     func didTableViewCellLoad(index: Int, urlString: String?)
     func didTabAccessoryButton(mate: Mate)
 }
@@ -39,13 +39,14 @@ final class MateListPresenter: MateListPresentable {
         self.output = output
     }
 
-    func viewDidLoad() {
+    func viewWillAppear() {
         guard let userID = SessionManager.shared.session?.user?.userID else {
             SNMLogger.error("세션 없음")
             // FIXME: 세션 없음 - 앱 라우터에서 로그인으로 튕기게 하거나 해야할듯
             return
         }
         interactor?.requestMateList(userID: userID)
+        SNMLogger.info("메이트 리스트 호출")
     }
 
     func didTableViewCellLoad(index: Int, urlString: String?) {

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
@@ -19,9 +19,9 @@ final class MateListViewController: BaseViewController, MateListViewable {
     private var cancellables: Set<AnyCancellable> = []
     private let tableView: UITableView = UITableView()
 
-    override func viewDidLoad() {
-        presenter?.viewDidLoad()
-        super.viewDidLoad()
+    override func viewWillAppear(_ animated: Bool) {
+        presenter?.viewWillAppear()
+        super.viewWillAppear(animated)
     }
 
     override func configureAttributes() {


### PR DESCRIPTION
- 탭 바에서 화면 전환을 할 때, viewDidLoad 라이프 사이클 메소드는 실행되지 않습니다.
- 기존에 viewDidLoad에 맞춰 서버에서 이미지를 불러오는 로직을 viewWillAppear로 옮겼습니다.

### 🔖  Issue Number

close #131 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 

- TabBar 화면 전환은 `viewDidLoad`를 실행하지 않습니다.
- `viewDidLoad` 시점에서 동작하던 메이트 리스트 불러오기 동작을 `viewWillAppear`시점으로 옮겼습니다.

https://github.com/user-attachments/assets/d258b3e5-8293-4e24-a6cb-4977990dd81f

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 현재 메이트 리스트 뷰에서 더 이상 `viewDidLoad` 관련 커스텀 메소드를 실행하지 않으므로, 뷰에서 해당 메소드를 오버라이드 하던 내용을 삭제하고, 프레젠터에서도 관련 메소드를 삭제했습니다.

### 👻 레퍼런스
<img src = "https://github.com/user-attachments/assets/8dad4320-1509-4337-a047-f2697b89b5bd" width = 500>
