### PR TITLE
[feat] 서버에 저장되는 이미지를 jpg로 압축하기

### DIFF
--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/Presenter/ProfileCreatePresenter.swift
@@ -40,7 +40,8 @@ final class ProfileCreatePresenter: ProfileCreatePresentable {
     }
 
     func didTapSubmitButton(nickname: String, image: UIImage?) {
-        let imageData = interactor?.convertImageToData(image: image)
+        let pngData = interactor?.convertImageToPNGData(image: image)
+        let jpgData = interactor?.convertImageToJPGData(image: image)
         let userInfo = UserInfo(
             name: dogInfo.name,
             age: dogInfo.age,
@@ -52,7 +53,10 @@ final class ProfileCreatePresenter: ProfileCreatePresentable {
             profileImage: nil
         )
         // TODO: SubmitButton disable 필요
-        interactor?.signInWithProfileData(dogInfo: userInfo, imageData: imageData)
+        interactor?.signInWithProfileData(
+            dogInfo: userInfo,
+            imageData: (png: pngData, jpg: jpgData)
+        )
     }
 }
 


### PR DESCRIPTION
- 로컬에는 png로 저장할 수 있도록 했습니다.

### 🔖  Issue Number

close #134 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [X] 이미지를 jpg로 압축하기
- [X] 서버에 이미지를 jpg로 저장하기

<img width="487" alt="Screenshot 2024-11-30 at 5 15 57 PM" src="https://github.com/user-attachments/assets/33a0d487-e82d-4051-8850-be88776cda48">
<img width="490" alt="Screenshot 2024-11-30 at 5 15 08 PM" src="https://github.com/user-attachments/assets/858f8652-6014-4918-bf06-bcfe71d8723c">

서버에 저장되는 이미지 용량을 약 1/10 수준으로 줄일 수 있었습니다.