### PR TITLE
[feat] 알림리스트 가져오는 UseCase 구현

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		320047652CF6B86D00D08B6D /* RespondMateRequestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047642CF6B83B00D08B6D /* RespondMateRequestUseCase.swift */; };
 		320047832CF70CA300D08B6D /* PresentAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047822CF70C9E00D08B6D /* PresentAnimator.swift */; };
 		320047852CF80B2600D08B6D /* MateList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047842CF80B2200D08B6D /* MateList.swift */; };
+		320047A82CFB0E2B00D08B6D /* NotiListDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047A72CFB0E2500D08B6D /* NotiListDTO.swift */; };
+		320047AA2CFB1C6200D08B6D /* RequestNotiListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047A92CFB1C5300D08B6D /* RequestNotiListUseCase.swift */; };
 		9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */; };
 		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
 		995D94622CE598FD005A47BF /* NIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94612CE598F0005A47BF /* NIManager.swift */; };
@@ -268,6 +270,8 @@
 		320047642CF6B83B00D08B6D /* RespondMateRequestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RespondMateRequestUseCase.swift; sourceTree = "<group>"; };
 		320047822CF70C9E00D08B6D /* PresentAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentAnimator.swift; sourceTree = "<group>"; };
 		320047842CF80B2200D08B6D /* MateList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateList.swift; sourceTree = "<group>"; };
+		320047A72CFB0E2500D08B6D /* NotiListDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiListDTO.swift; sourceTree = "<group>"; };
+		320047A92CFB1C5300D08B6D /* RequestNotiListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestNotiListUseCase.swift; sourceTree = "<group>"; };
 		9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUserInfoRemoteUseCase.swift; sourceTree = "<group>"; };
 		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
 		995D94612CE598F0005A47BF /* NIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIManager.swift; sourceTree = "<group>"; };
@@ -531,6 +535,7 @@
 		320047A42CF9E2A200D08B6D /* RequestUseCase */ = {
 			isa = PBXGroup;
 			children = (
+				320047A92CFB1C5300D08B6D /* RequestNotiListUseCase.swift */,
 				FDE768A02CF7872E00B5DE88 /* RequestNotificationAuthUseCase.swift */,
 				A2BD4A002CF7AD4300AC72A7 /* RequestMateInfoUseCase.swift */,
 				9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */,
@@ -647,6 +652,7 @@
 		A2BD49F02CF72A8800AC72A7 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				320047A72CFB0E2500D08B6D /* NotiListDTO.swift */,
 				320047842CF80B2200D08B6D /* MateList.swift */,
 				995D94D12CEDF031005A47BF /* MPCProfileDropDTO.swift */,
 				A2BD49F52CF72B4000AC72A7 /* WalkNotiDTO.swift */,
@@ -1873,6 +1879,7 @@
 				A2BA1B9A2CF260A50080575A /* MateListRouter.swift in Sources */,
 				320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */,
 				FD119F4A2CED875F00BE22BD /* RequestUserLocationUseCase.swift in Sources */,
+				320047A82CFB0E2B00D08B6D /* NotiListDTO.swift in Sources */,
 				995D94AC2CECFA30005A47BF /* RequestMatePresenter.swift in Sources */,
 				FD0634262CE596B5003C9D6B /* Endpoint.swift in Sources */,
 				320044872CEC85CB00D08B6D /* ProfileView.swift in Sources */,
@@ -1930,6 +1937,7 @@
 				FD880B602CF4327F0093BEB9 /* SaveProfileImageUseCase.swift in Sources */,
 				320047652CF6B86D00D08B6D /* RespondMateRequestUseCase.swift in Sources */,
 				FD331A562CF23C5300F39426 /* WalkLogListViewController.swift in Sources */,
+				320047AA2CFB1C6200D08B6D /* RequestNotiListUseCase.swift in Sources */,
 				320044672CE6125100D08B6D /* DataManager.swift in Sources */,
 				3200449C2CEDA87800D08B6D /* RespondWalkRequestUseCase.swift in Sources */,
 				FDEAEA7A2CE3148D005890FA /* BaseView.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
@@ -26,7 +26,9 @@ enum Environment {
     enum SupabaseTableName {
         static let userInfo = "user_info"
         static let notification = "notification"
-        static let notification_list = "notification_list"
+        static let notificationList = "notification_list"
         static let matelist = "mate_list"
+        static let matelistFunction = "rpc/get_user_info_from_mate_list"
+        static let notificationListFunction = "rpc/notification_list"
     }
 }

--- a/SniffMeet/SniffMeet/Source/DTO/NotiListDTO.swift
+++ b/SniffMeet/SniffMeet/Source/DTO/NotiListDTO.swift
@@ -1,0 +1,15 @@
+//
+//  NotiListDTO.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 11/30/24.
+//
+import Foundation
+
+struct NotiListInsertDTO: Encodable {
+    let id: UUID
+    let notifications: [UUID] = []
+    enum CodingKeys: String, CodingKey {
+        case id, notifications
+    }
+}

--- a/SniffMeet/SniffMeet/Source/DTO/NotiListDTO.swift
+++ b/SniffMeet/SniffMeet/Source/DTO/NotiListDTO.swift
@@ -6,10 +6,20 @@
 //
 import Foundation
 
-struct NotiListInsertDTO: Encodable {
+/// 회원가입 할 때, 빈 배열로 insert할 때 사용하는 DTO
+struct WalkNotiListInsertDTO: Encodable {
     let id: UUID
     let notifications: [UUID] = []
     enum CodingKeys: String, CodingKey {
         case id, notifications
+    }
+}
+
+/// 노티 리스트를 요청할 때, body에 보내야하는 DTO
+struct WalkNotiListRequestDTO: Encodable {
+    let userId: UUID
+    
+    enum CodingKeys: String, CodingKey {
+        case userId = "p_id"
     }
 }

--- a/SniffMeet/SniffMeet/Source/DTO/WalkNotiDTO.swift
+++ b/SniffMeet/SniffMeet/Source/DTO/WalkNotiDTO.swift
@@ -14,7 +14,19 @@ struct WalkNotiDTO: Decodable {
     let latitude: Double
     let longtitude: Double
     let senderId: UUID
+    let receiverId: UUID
     let senderName: String
+    let category: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case createdAt = "created_at"
+        case message, latitude, longtitude
+        case senderId = "sender"
+        case receiverId = "receiver"
+        case senderName = "name"
+        case category
+    }
     
     var createdAtDate: Date? {
         let dateFormatter = ISO8601DateFormatter()
@@ -28,6 +40,7 @@ struct WalkNotiDTO: Decodable {
                  latitude: latitude,
                  longtitude: longtitude,
                  senderId: senderId,
-                 senderName: senderName)
+                 senderName: senderName,
+                 category: category)
     }
 }

--- a/SniffMeet/SniffMeet/Source/Entity/WalkRequest.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/WalkRequest.swift
@@ -45,6 +45,7 @@ struct WalkNoti {
     let longtitude: Double
     let senderId: UUID
     let senderName: String
+    let category: String
 }
 extension WalkNoti {
     static let example = WalkNoti(id: UUID(),
@@ -53,5 +54,6 @@ extension WalkNoti {
                                   latitude: 11,
                                   longtitude: 11,
                                   senderId: UUID(),
-                                  senderName: "지성")
+                                  senderName: "지성",
+                                  category: "walkRequest")
 }

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
@@ -13,7 +13,7 @@ protocol RemoteDatabaseManager {
     func fetchDataWithID(from table: String, with id: UUID) async throws -> Data
     func insertData(into table: String, with data: Data) async throws
     func updateData(into table: String, with data: Data) async throws
-    func fetchUserInfoFromMateList() async throws -> Data
+    func fetchList(into table: String) async throws -> Data
 }
 
 final class SupabaseDatabaseManager: RemoteDatabaseManager {
@@ -95,7 +95,7 @@ final class SupabaseDatabaseManager: RemoteDatabaseManager {
         )
     }
     
-    func fetchUserInfoFromMateList() async throws -> Data {
+    func fetchList(into table: String) async throws -> Data {
         if SessionManager.shared.isExpired {
             try await SupabaseAuthManager.shared.refreshSession()
         }
@@ -107,7 +107,8 @@ final class SupabaseDatabaseManager: RemoteDatabaseManager {
         }
 
         let response = try await networkProvider.request(
-            with: SupabaseDatabaseRequest.fetchUserInfoFromMateList(
+            with: SupabaseDatabaseRequest.fetchList(
+                table: table,
                 data: data,
                 accessToken: session.accessToken
             )

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseManager.swift
@@ -13,7 +13,7 @@ protocol RemoteDatabaseManager {
     func fetchDataWithID(from table: String, with id: UUID) async throws -> Data
     func insertData(into table: String, with data: Data) async throws
     func updateData(into table: String, with data: Data) async throws
-    func fetchList(into table: String) async throws -> Data
+    func fetchList(into table: String, with data: Data) async throws -> Data
 }
 
 final class SupabaseDatabaseManager: RemoteDatabaseManager {
@@ -95,14 +95,11 @@ final class SupabaseDatabaseManager: RemoteDatabaseManager {
         )
     }
     
-    func fetchList(into table: String) async throws -> Data {
+    func fetchList(into table: String, with data: Data) async throws -> Data {
         if SessionManager.shared.isExpired {
             try await SupabaseAuthManager.shared.refreshSession()
         }
-        guard let session = SessionManager.shared.session,
-              let userID = SessionManager.shared.session?.user?.userID,
-              let data = try? JSONEncoder().encode(MateListRequestDTO(userId: userID))
-        else {
+        guard let session = SessionManager.shared.session else {
             throw SupabaseError.sessionNotExist
         }
 

--- a/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseRequest.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/Database/SupabaseDatabaseRequest.swift
@@ -12,7 +12,7 @@ enum SupabaseDatabaseRequest {
     case fetchDataWithID(table: String, id: UUID, accessToken: String)
     case insertData(table: String, accessToken: String, data: Data)
     case updateData(table: String, id: UUID, accessToken: String, data: Data)
-    case fetchUserInfoFromMateList(data: Data, accessToken: String)
+    case fetchList(table: String, data: Data, accessToken: String)
 }
 
 extension SupabaseDatabaseRequest: SNMRequestConvertible {
@@ -47,10 +47,10 @@ extension SupabaseDatabaseRequest: SNMRequestConvertible {
                 query: ["id": "eq.\(id)"]
             )
             
-        case .fetchUserInfoFromMateList( _, _):
+        case .fetchList(let table,  _, _):
             return Endpoint(
                 baseURL: SupabaseConfig.baseURL,
-                path: "rest/v1/rpc/get_user_info_from_mate_list",
+                path: "rest/v1/\(table)",
                 method: .post // SQL 함수 호출은 POST 요청으로 수행
             )
         }
@@ -83,7 +83,7 @@ extension SupabaseDatabaseRequest: SNMRequestConvertible {
                 header: header,
                 body: data
             )
-        case .fetchUserInfoFromMateList(let data, let accessToken):
+        case .fetchList(_, let data, let accessToken):
             header["Authorization"] = "Bearer \(accessToken)"
             
             return SNMRequestType.compositePlain(

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestMateListUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestMateListUseCase.swift
@@ -19,7 +19,7 @@ struct RequestMateListUseCaseImpl: RequestMateListUseCase {
         let decoder = JSONDecoder()
 
         do {
-            let data = try await remoteDatabaseManager.fetchUserInfoFromMateList()
+            let data = try await remoteDatabaseManager.fetchList(into: Environment.SupabaseTableName.matelistFunction)
             let mateDTOList = try decoder.decode([UserInfoDTO].self, from: data)
             return mateDTOList.map {
                 Mate(name: $0.dogName,

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestNotiListUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestNotiListUseCase.swift
@@ -1,0 +1,41 @@
+//
+//  RequestNotiListUseCase.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 11/30/24.
+//
+import Foundation
+
+protocol RequestNotiListUseCase {
+    var remoteManager: (any RemoteDatabaseManager) { get }
+    func execute() async -> [WalkNoti]
+}
+
+struct RequestNotiListUseCaseImpl: RequestNotiListUseCase {
+    var remoteManager: (any RemoteDatabaseManager)
+    let encoder: JSONEncoder
+    let decoder: JSONDecoder
+    
+    init(remoteManager: any RemoteDatabaseManager) {
+        self.remoteManager = remoteManager
+        decoder = JSONDecoder()
+        encoder = JSONEncoder()
+    }
+    
+    func execute() async -> [WalkNoti] {
+        let tableName = Environment.SupabaseTableName.notificationListFunction
+
+        do {
+            guard let userID = SessionManager.shared.session?.user?.userID else { return [] }
+            
+            let requestData = try encoder.encode(WalkNotiListRequestDTO(userId: userID))
+            let data = try await remoteManager.fetchList(into: tableName, with: requestData)
+            let walkDTOList = try decoder.decode([WalkNotiDTO].self, from: data)
+            
+            return walkDTOList.map { $0.toEntity() }
+        } catch {
+            SNMLogger.error("RequestNotiListUseCaseImpl: \(error.localizedDescription)")
+            return []
+        }
+    }
+}

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/CreateAccountUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/CreateAccountUseCase.swift
@@ -32,7 +32,16 @@ struct CreateAccountUseCaseImpl: CreateAccountUseCase {
                 with: mateListData
             )
         } catch {
-            SNMLogger.error("\(error.localizedDescription)")
+            SNMLogger.error("mate list insert error: \(error.localizedDescription)")
+        }
+        do {
+            let notiListData = try encoder.encode(NotiListInsertDTO(id: info.id))
+            try await SupabaseDatabaseManager.shared.insertData(
+                into: Environment.SupabaseTableName.notification_list,
+                with: notiListData
+            )
+        } catch {
+            SNMLogger.error("notifiaction list insert error: \(error.localizedDescription)")
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/CreateAccountUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/CreateAccountUseCase.swift
@@ -35,7 +35,7 @@ struct CreateAccountUseCaseImpl: CreateAccountUseCase {
             SNMLogger.error("mate list insert error: \(error.localizedDescription)")
         }
         do {
-            let notiListData = try encoder.encode(NotiListInsertDTO(id: info.id))
+            let notiListData = try encoder.encode(WalkNotiListInsertDTO(id: info.id))
             try await SupabaseDatabaseManager.shared.insertData(
                 into: Environment.SupabaseTableName.notificationList,
                 with: notiListData

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/CreateAccountUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/CreateAccountUseCase.swift
@@ -37,7 +37,7 @@ struct CreateAccountUseCaseImpl: CreateAccountUseCase {
         do {
             let notiListData = try encoder.encode(NotiListInsertDTO(id: info.id))
             try await SupabaseDatabaseManager.shared.insertData(
-                into: Environment.SupabaseTableName.notification_list,
+                into: Environment.SupabaseTableName.notificationList,
                 with: notiListData
             )
         } catch {


### PR DESCRIPTION
### 🔖  Issue Number

close #133 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  알림 리스트 insert DTO와 리스트를 가져올 때 사용하는 request, response DTO 선언
- [x] 서버에 알림리스트 가져오는 PostgreSQL 함수 작성 및 notification, notification_list 테이블 권한 변경 
- [x] 기존 요청 Request 타입과 함수 수정 
- [x] 알림 리스트 가져오는 UseCase 구현

### 📝 PR 특이사항 

- 특이 사항 1
테이블 명처럼 함수명도 접근하는데 쓰이기 때문에 변수로 따로 선언하여 관리했습니다. PostgreSQL rpc(함수)에 요청을 보내는 경우 일반적으로 사용할 수 있도록 함수와 RequestType을 수정했습니다. 

```swift
//  SupabaseDatabaseManager.swift
func fetchList(into table: String, with data: Data) async throws -> Data {
        if SessionManager.shared.isExpired {
            try await SupabaseAuthManager.shared.refreshSession()
        }
        guard let session = SessionManager.shared.session else {
            throw SupabaseError.sessionNotExist
        }

        let response = try await networkProvider.request(
            with: SupabaseDatabaseRequest.fetchList(
                table: table,
                data: data,
                accessToken: session.accessToken
            )
        )
        return response.data
    }
```

