### PR TITLE
[feat] 정보 수정 뷰 ui 및 VIPER 모듈 초기 세팅

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		99FA4E792CE0FBBF00553C2E /* ProfileInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */; };
 		A202A1152CEDD50700B98203 /* SupabaseDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A202A1142CEDD50700B98203 /* SupabaseDatabaseManager.swift */; };
 		A202A1172CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A202A1162CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift */; };
+		A2082B972CFC0151005B7502 /* ProfileEditInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2082B962CFC0151005B7502 /* ProfileEditInteractor.swift */; };
+		A2082B992CFC01D9005B7502 /* ProfileEditRoutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2082B982CFC01D9005B7502 /* ProfileEditRoutable.swift */; };
 		A20E71502CEC595C00272B25 /* SupabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E714F2CEC595C00272B25 /* SupabaseError.swift */; };
 		A20E71522CEC5FE900272B25 /* SupabaseUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E71512CEC5FE900272B25 /* SupabaseUserResponse.swift */; };
 		A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21435F62CE20D2500564A4D /* TabBarController.swift */; };
@@ -93,6 +95,8 @@
 		A2BD49FD2CF7712000AC72A7 /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2BD49FC2CF7712000AC72A7 /* Size.swift */; };
 		A2BD49FF2CF7712800AC72A7 /* Keyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2BD49FE2CF7712800AC72A7 /* Keyword.swift */; };
 		A2BD4A012CF7AD4300AC72A7 /* RequestMateInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2BD4A002CF7AD4300AC72A7 /* RequestMateInfoUseCase.swift */; };
+		A2BD4A092CF83D8D00AC72A7 /* ProfileEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2BD4A082CF83D8D00AC72A7 /* ProfileEditViewController.swift */; };
+		A2BD4A0B2CF8499900AC72A7 /* ProfileEditPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2BD4A0A2CF8499900AC72A7 /* ProfileEditPresenter.swift */; };
 		A2C328862CE245AC00D255AB /* TabBarModuleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328852CE245AC00D255AB /* TabBarModuleBuilder.swift */; };
 		A2C328882CE2481900D255AB /* HomeModuleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328872CE2481900D255AB /* HomeModuleBuilder.swift */; };
 		A2C328922CE3BEA000D255AB /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328912CE3BEA000D255AB /* AppRouter.swift */; };
@@ -279,6 +283,8 @@
 		99FA4E782CE0FBBF00553C2E /* ProfileInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInputViewController.swift; sourceTree = "<group>"; };
 		A202A1142CEDD50700B98203 /* SupabaseDatabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseDatabaseManager.swift; sourceTree = "<group>"; };
 		A202A1162CEDD5EF00B98203 /* SupabaseDatabaseRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseDatabaseRequest.swift; sourceTree = "<group>"; };
+		A2082B962CFC0151005B7502 /* ProfileEditInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditInteractor.swift; sourceTree = "<group>"; };
+		A2082B982CFC01D9005B7502 /* ProfileEditRoutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditRoutable.swift; sourceTree = "<group>"; };
 		A20E714F2CEC595C00272B25 /* SupabaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseError.swift; sourceTree = "<group>"; };
 		A20E71512CEC5FE900272B25 /* SupabaseUserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseUserResponse.swift; sourceTree = "<group>"; };
 		A21435F62CE20D2500564A4D /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
@@ -306,6 +312,8 @@
 		A2BD49FC2CF7712000AC72A7 /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
 		A2BD49FE2CF7712800AC72A7 /* Keyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keyword.swift; sourceTree = "<group>"; };
 		A2BD4A002CF7AD4300AC72A7 /* RequestMateInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMateInfoUseCase.swift; sourceTree = "<group>"; };
+		A2BD4A082CF83D8D00AC72A7 /* ProfileEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewController.swift; sourceTree = "<group>"; };
+		A2BD4A0A2CF8499900AC72A7 /* ProfileEditPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditPresenter.swift; sourceTree = "<group>"; };
 		A2C328852CE245AC00D255AB /* TabBarModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarModuleBuilder.swift; sourceTree = "<group>"; };
 		A2C328872CE2481900D255AB /* HomeModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModuleBuilder.swift; sourceTree = "<group>"; };
 		A2C328912CE3BEA000D255AB /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
@@ -666,6 +674,49 @@
 			path = DogTraits;
 			sourceTree = "<group>";
 		};
+		A2BD4A022CF83CEB00AC72A7 /* EditProfile */ = {
+			isa = PBXGroup;
+			children = (
+				A2BD4A042CF83D1000AC72A7 /* View */,
+				A2BD4A052CF83D1500AC72A7 /* Interactor */,
+				A2BD4A062CF83D1D00AC72A7 /* Presenter */,
+				A2BD4A072CF83D2200AC72A7 /* Router */,
+			);
+			path = EditProfile;
+			sourceTree = "<group>";
+		};
+		A2BD4A042CF83D1000AC72A7 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				A2BD4A082CF83D8D00AC72A7 /* ProfileEditViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		A2BD4A052CF83D1500AC72A7 /* Interactor */ = {
+			isa = PBXGroup;
+			children = (
+				A2082B962CFC0151005B7502 /* ProfileEditInteractor.swift */,
+			);
+			path = Interactor;
+			sourceTree = "<group>";
+		};
+		A2BD4A062CF83D1D00AC72A7 /* Presenter */ = {
+			isa = PBXGroup;
+			children = (
+				A2BD4A0A2CF8499900AC72A7 /* ProfileEditPresenter.swift */,
+			);
+			path = Presenter;
+			sourceTree = "<group>";
+		};
+		A2BD4A072CF83D2200AC72A7 /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				A2082B982CFC01D9005B7502 /* ProfileEditRoutable.swift */,
+			);
+			path = Router;
+			sourceTree = "<group>";
+		};
 		A2C328892CE2F4F600D255AB /* Router */ = {
 			isa = PBXGroup;
 			children = (
@@ -795,6 +846,7 @@
 		FDA491332CD9FE7C00A36FB0 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				A2BD4A022CF83CEB00AC72A7 /* EditProfile */,
 				A2BD49F02CF72A8800AC72A7 /* DTO */,
 				320044792CEC490600D08B6D /* Entity */,
 				320044782CEC48FB00D08B6D /* UseCase */,
@@ -1896,6 +1948,7 @@
 				FD331A502CF235C400F39426 /* WalkLogPageViewController.swift in Sources */,
 				FD119F422CED865B00BE22BD /* SelectLocationViewController.swift in Sources */,
 				A25BE4522CEBB5A900886763 /* SupabaseSession.swift in Sources */,
+				A2BD4A092CF83D8D00AC72A7 /* ProfileEditViewController.swift in Sources */,
 				3200446F2CEB23A700D08B6D /* CardPresentationController.swift in Sources */,
 				320043932CDF3D7F00D08B6D /* KeywordView.swift in Sources */,
 				320044772CEB4E1E00D08B6D /* RequestWalkUseCase.swift in Sources */,
@@ -1960,8 +2013,11 @@
 				3200441A2CE48A3D00D08B6D /* MPCBroswer.swift in Sources */,
 				A25BE4562CEBB63A00886763 /* SupabaseUser.swift in Sources */,
 				A2BA1B922CF1E8C60080575A /* MateListViewController.swift in Sources */,
+				A2082B972CFC0151005B7502 /* ProfileEditInteractor.swift in Sources */,
 				A24082722CEB36B8009109A0 /* SupabaseTokenRequest.swift in Sources */,
+				A2082B992CFC01D9005B7502 /* ProfileEditRoutable.swift in Sources */,
 				3200437C2CDCA6F300D08B6D /* (null) in Sources */,
+				A2BD4A0B2CF8499900AC72A7 /* ProfileEditPresenter.swift in Sources */,
 				3200445A2CE5B3AA00D08B6D /* ProfileCreateInteractor.swift in Sources */,
 				A2C328922CE3BEA000D255AB /* AppRouter.swift in Sources */,
 				320043702CDC9A0D00D08B6D /* (null) in Sources */,

--- a/SniffMeet/SniffMeet/Source/EditProfile/Interactor/ProfileEditInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/EditProfile/Interactor/ProfileEditInteractor.swift
@@ -1,0 +1,10 @@
+//
+//  ProfileEditInteractor.swift
+//  SniffMeet
+//
+//  Created by Kelly Chui on 12/1/24.
+//
+
+import Foundation
+
+protocol ProfileEditInteractable: AnyObject {}

--- a/SniffMeet/SniffMeet/Source/EditProfile/Presenter/ProfileEditPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/EditProfile/Presenter/ProfileEditPresenter.swift
@@ -1,0 +1,16 @@
+//
+//  ProfileEditPresenter.swift
+//  SniffMeet
+//
+//  Created by Kelly Chui on 11/28/24.
+//
+
+import Foundation
+
+protocol ProfileEditPresentable: AnyObject {}
+
+protocol ProfileEditInteractorOutput: AnyObject {}
+
+// MARK: - ProfileEditPresenterOutput
+
+protocol ProfileEditPresenterOutput {}

--- a/SniffMeet/SniffMeet/Source/EditProfile/Router/ProfileEditRoutable.swift
+++ b/SniffMeet/SniffMeet/Source/EditProfile/Router/ProfileEditRoutable.swift
@@ -1,0 +1,12 @@
+//
+//  ProfileEditRoutable.swift
+//  SniffMeet
+//
+//  Created by Kelly Chui on 12/1/24.
+//
+
+import Foundation
+
+protocol ProfileEditRoutable: Routable {}
+
+protocol ProfileEditBuildable {}

--- a/SniffMeet/SniffMeet/Source/EditProfile/View/ProfileEditViewController.swift
+++ b/SniffMeet/SniffMeet/Source/EditProfile/View/ProfileEditViewController.swift
@@ -1,0 +1,354 @@
+//
+//  ProfileEditView.swift
+//  SniffMeet
+//
+//  Created by Kelly Chui on 11/28/24.
+//
+
+import Combine
+import UIKit
+
+protocol ProfileEditViewable: AnyObject {
+    // var presenter: (any ProfileEditPresentable)?
+}
+
+final class ProfileEditViewController: BaseViewController, ProfileEditViewable {
+    var presenter: ProfileEditPresentable?
+    private var cancellables = Set<AnyCancellable>()
+    private var profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "ImagePlaceholder")
+        imageView.contentMode = .scaleAspectFill
+        return imageView
+    }()
+    private var addPhotoButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "photo"), for: .normal)
+        button.backgroundColor = SNMColor.mainNavy
+        button.setTitleColor(SNMColor.white, for: .normal)
+        button.tintColor = SNMColor.white
+        return button
+    }()
+    private var nameTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "이름"
+        label.font = .systemFont(ofSize: .init(16), weight: .regular)
+        return label
+    }()
+    private var nameTextField: InputTextField = InputTextField(placeholder: "반려견 이름을 입력해주세요")
+    private var ageTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "나이"
+        label.font = .systemFont(ofSize: .init(16), weight: .regular)
+        return label
+    }()
+    private var ageTextField: InputTextField = InputTextField(placeholder: "반려견 나이를 입력해주세요")
+    private var sizeSelectionLabel: UILabel = {
+        let label = UILabel()
+        label.text = Context.sizeLabel
+        label.font = .systemFont(ofSize: .init(16), weight: .regular)
+        return label
+    }()
+    private var sizeSegmentedControl: UISegmentedControl = {
+        let segmentedControl = UISegmentedControl(items: Context.sizeArr)
+        segmentedControl.selectedSegmentIndex = 0
+        return segmentedControl
+    }()
+    private var keywordSelectionLabel: UILabel = {
+        let label = UILabel()
+        label.text = Context.keywordLabel
+        label.font = .systemFont(ofSize: .init(16), weight: .regular)
+        return label
+    }()
+    private var energeticKeywordButton = KeywordButton(title: Context.energeticKeywordLabel)
+    private var smartKeywordButton = KeywordButton(title: Context.smartKeywordLabel)
+    private var friendlyKeywordButton = KeywordButton(title: Context.friendlyKeywordLabel)
+    private var shyKeywordButton = KeywordButton(title: Context.shyKeywordLabel)
+    private var independentKeywordButton = KeywordButton(title: Context.independentKeywordLabel)
+    private var keywordStackView = UIStackView()
+    private var keywordButtons: [KeywordButton] {
+        [energeticKeywordButton,
+         smartKeywordButton,
+         friendlyKeywordButton,
+         shyKeywordButton,
+         independentKeywordButton]
+    }
+    private var nextButton = PrimaryButton(title: Context.nextBtnTitle)
+
+    override func viewDidLoad() {
+        setupBinding()
+        super.viewDidLoad()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        profileImageView.makeViewCircular()
+        addPhotoButton.makeViewCircular()
+    }
+
+    override func configureHierachy() {
+        [profileImageView,
+         addPhotoButton,
+         nameTextLabel,
+         nameTextField,
+         ageTextLabel,
+         ageTextField,
+         sizeSelectionLabel,
+         sizeSegmentedControl,
+         keywordSelectionLabel,
+         keywordStackView,
+         nextButton].forEach { subview in
+            view.addSubview(subview)
+        }
+
+        keywordButtons.forEach { keywordButton in
+            keywordStackView.addArrangedSubview(keywordButton)
+        }
+    }
+
+    override func configureConstraints() {
+        disableAutoresizingMaskForSubviews()
+        configureNextButtonConstraints()
+        configureProfileImageViewConstraints()
+
+        NSLayoutConstraint.activate([
+            nameTextLabel.topAnchor.constraint(
+                equalTo: profileImageView.bottomAnchor,
+                constant: Context.largeVerticalPadding
+            ),
+            nameTextLabel.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: Context.horizontalPadding
+            ),
+            nameTextField.topAnchor.constraint(
+                equalTo: nameTextLabel.bottomAnchor,
+                constant: Context.basicVerticalPadding
+            ),
+            nameTextField.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: Context.horizontalPadding
+            ),
+            nameTextField.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -Context.horizontalPadding
+            ),
+            ageTextLabel.topAnchor.constraint(
+                equalTo: nameTextField.bottomAnchor,
+                constant: Context.basicVerticalPadding
+            ),
+            ageTextLabel.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: Context.horizontalPadding
+            ),
+            ageTextField.topAnchor.constraint(
+                equalTo: ageTextLabel.bottomAnchor,
+                constant: Context.basicVerticalPadding
+            ),
+            ageTextField.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: Context.horizontalPadding
+            ),
+            ageTextField.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -Context.horizontalPadding
+            ),
+            sizeSelectionLabel.topAnchor.constraint(
+                equalTo: ageTextField.bottomAnchor,
+                constant: Context.basicVerticalPadding
+            ),
+            sizeSelectionLabel.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: Context.horizontalPadding
+            ),
+            sizeSegmentedControl.topAnchor.constraint(
+                equalTo: sizeSelectionLabel.bottomAnchor,
+                constant: Context.basicVerticalPadding
+            ),
+            sizeSegmentedControl.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: Context.horizontalPadding
+            ),
+            sizeSegmentedControl.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -Context.horizontalPadding
+            ),
+            keywordSelectionLabel.topAnchor.constraint(
+                equalTo: sizeSegmentedControl.bottomAnchor,
+                constant: Context.basicVerticalPadding
+            ),
+            keywordSelectionLabel.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: Context.horizontalPadding
+            ),
+            keywordStackView.topAnchor.constraint(
+                equalTo: keywordSelectionLabel.bottomAnchor,
+                constant: Context.basicVerticalPadding
+            ),
+            keywordStackView.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: Context.horizontalPadding
+            ),
+            keywordStackView.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: Context.horizontalPadding
+            )
+        ])
+        configureButtonConstraints()
+    }
+
+    override func configureAttributes() {
+
+    }
+
+    override func bind() {}
+
+    private func setupBinding() {
+        let namePublisher = nameTextField
+            .publisher(for: \.text)
+            .map { $0 ?? "" }
+            .eraseToAnyPublisher()
+        let agePublisher = ageTextField
+            .publisher(for: \.text)
+            .map { $0 ?? "0" }
+            .eraseToAnyPublisher()
+        Publishers.CombineLatest(namePublisher, agePublisher)
+            .map { !$0.isEmpty && Int($1) != nil }
+            .receive(on: RunLoop.main)
+            .sink { [weak self] isEnabled in
+                self?.nextButton.isEnabled = isEnabled
+            }
+            .store(in: &cancellables)
+    }
+    private func disableAutoresizingMaskForSubviews() {
+        [nameTextLabel,
+         nameTextField,
+         ageTextLabel,
+         ageTextField,
+         sizeSelectionLabel,
+         sizeSegmentedControl,
+         keywordSelectionLabel,
+         keywordStackView,
+         nextButton,
+         profileImageView,
+         addPhotoButton].forEach { subview in
+            subview.translatesAutoresizingMaskIntoConstraints = false
+        }
+        keywordButtons.forEach { subview in
+            subview.translatesAutoresizingMaskIntoConstraints = false
+        }
+    }
+
+    private func configureNextButtonConstraints() {
+        NSLayoutConstraint.activate([
+            nextButton.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -32
+            ),
+            nextButton.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: 24
+            ),
+            nextButton.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -24
+            )
+        ])
+    }
+
+    private func configureProfileImageViewConstraints() {
+        NSLayoutConstraint.activate([
+            profileImageView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: 60
+            ),
+            profileImageView.centerXAnchor.constraint(
+                equalTo: view.centerXAnchor
+            ),
+            profileImageView.widthAnchor.constraint(
+                equalToConstant: 100
+            ),
+            profileImageView.heightAnchor.constraint(
+                equalToConstant: 100
+            ),
+            addPhotoButton.widthAnchor.constraint(
+                equalToConstant: 32
+            ),
+            addPhotoButton.heightAnchor.constraint(
+                equalToConstant: 32
+            ),
+            addPhotoButton.trailingAnchor.constraint(
+                equalTo: profileImageView.trailingAnchor
+            ),
+            addPhotoButton.bottomAnchor.constraint(
+                equalTo: profileImageView.bottomAnchor
+            )
+        ])
+
+    }
+    
+    func configureButtonConstraints() {
+        keywordStackView.spacing = Context.smallVerticalPadding
+        keywordStackView.axis = .horizontal
+        keywordStackView.distribution = .fillProportionally
+
+        NSLayoutConstraint.activate([
+            keywordStackView.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: Context.horizontalPadding),
+            keywordStackView.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -Context.horizontalPadding),
+            keywordStackView.topAnchor.constraint(
+                equalTo: keywordSelectionLabel.bottomAnchor,
+                constant: Context.basicVerticalPadding),
+            keywordStackView.heightAnchor.constraint(equalToConstant: 30)
+
+        ])
+    }
+
+    func setButtonAction() {
+        // next button
+        // binding 하여 기존 정보를 가져와야 합니다.
+
+        // keyword button
+        // 최대 2개까지만 선택, 2개 넘어가면 얼럿이든지 뭐든지 띄우기
+    }
+}
+
+// MARK: - ProfileEditViewControlle+UITextFieldDelegate
+
+extension ProfileEditViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField,
+                   shouldChangeCharactersIn range: NSRange,
+                   replacementString string: String) -> Bool
+    {
+        guard let text = textField.text else { return true }
+        let newLength = text.count + string.count - range.length
+        return newLength <= 2
+    }
+}
+
+extension ProfileEditViewController {
+    enum Context {
+        static let nextBtnTitle: String = "다음으로"
+        static let namePlaceholder: String = "반려견 이름을 입력해주세요."
+        static let agePlaceholder: String = "반려견 나이를 입력해주세요."
+        static let sexLabel: String = "반려견의 성별을 선택해주세요."
+        static let sizeLabel: String = "반려견의 크기를 선택해주세요."
+        static let sizeArr: [String] = [
+            Size.small.rawValue,
+            Size.medium.rawValue,
+            Size.big.rawValue
+        ]
+        static let keywordLabel: String = "반려견에 해당되는 키워드를 선택해주세요.(최대 2개)"
+        static let energeticKeywordLabel: String = Keyword.energetic.rawValue
+        static let smartKeywordLabel: String = Keyword.smart.rawValue
+        static let friendlyKeywordLabel: String = Keyword.friendly.rawValue
+        static let shyKeywordLabel: String = Keyword.shy.rawValue
+        static let independentKeywordLabel: String = Keyword.independent.rawValue
+        static let horizontalPadding: CGFloat = 24
+        static let smallVerticalPadding: CGFloat = 8
+        static let basicVerticalPadding: CGFloat = 16
+        static let largeVerticalPadding: CGFloat = 30
+    }
+}


### PR DESCRIPTION
### 🔖  Issue Number

#120 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  정보 수정 뷰 ui로 그리기
- [x]  VIPER 모듈 프로토콜 선언하기

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 기존 코드에서 많은 부분을 가져왔지만, 달라진 부분 (버튼 활성화 동작, 키워드 버튼 동작 등)이 있습니다.
- 컴바인을 이용해서 키워드 버튼이 최대 2개까지만 선택할 수 있도록 제한했습니다:
```swift
keywordButtons.forEach { keywordButton in
    keywordButton.publisher(event: .touchUpInside)
        .sink { [weak self] in
            if keywordButton.isSelected {
                if self?.selectedKeywordButtons.count ?? 0 < 2 {
                    self?.selectedKeywordButtons.append(keywordButton)
                } else {
                    keywordButton.isSelected = false
                }
            } else {
                self?.selectedKeywordButtons.removeAll { $0 == keywordButton }
            }
        }
        .store(in: &cancellables)
}
```
- 작성을 하다보니 `selectedKeywordButtons` 배열의 위치가 뷰인지, 프레젠터인지, 인터렉터인지 고민이 됩니다.. 아니면 필요가 없을 수도 있겠다는 생각을 했습니다. 이 부분에 있어서 좋은 의견 부탁드립니다.
    - 대략적으로 생각한 것은 combinelastest를 이용하여 버튼들의 상태를 모아서 지속적으로 퍼블리시 하는 것 입니다.