### PR TITLE
[feat] device token 서버 등록 로직 구현

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -107,6 +107,9 @@
 		FD06342A2CE596D0003C9D6B /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634292CE596C2003C9D6B /* NetworkProvider.swift */; };
 		FD06342C2CE5984D003C9D6B /* SNMNetworkResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD06342B2CE59843003C9D6B /* SNMNetworkResponse.swift */; };
 		FD0634312CE62578003C9D6B /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0634302CE62573003C9D6B /* AnyEncodable.swift */; };
+		FD1152752CFB9F44008955C4 /* CheckFirstLaunchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1152742CFB9F33008955C4 /* CheckFirstLaunchUseCase.swift */; };
+		FD1152772CFBA089008955C4 /* SaveFirstLaunchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1152762CFBA083008955C4 /* SaveFirstLaunchUseCase.swift */; };
+		FD1152792CFC3B29008955C4 /* SaveDeviceTokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1152782CFC3B23008955C4 /* SaveDeviceTokenDTO.swift */; };
 		FD119F422CED865B00BE22BD /* SelectLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD119F412CED865000BE22BD /* SelectLocationViewController.swift */; };
 		FD119F462CED868D00BE22BD /* ConvertLocationToTextUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD119F452CED867600BE22BD /* ConvertLocationToTextUseCase.swift */; };
 		FD119F482CED872C00BE22BD /* RequestLocationAuthUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD119F472CED872500BE22BD /* RequestLocationAuthUseCase.swift */; };
@@ -319,6 +322,9 @@
 		FD0634292CE596C2003C9D6B /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
 		FD06342B2CE59843003C9D6B /* SNMNetworkResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMNetworkResponse.swift; sourceTree = "<group>"; };
 		FD0634302CE62573003C9D6B /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
+		FD1152742CFB9F33008955C4 /* CheckFirstLaunchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckFirstLaunchUseCase.swift; sourceTree = "<group>"; };
+		FD1152762CFBA083008955C4 /* SaveFirstLaunchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveFirstLaunchUseCase.swift; sourceTree = "<group>"; };
+		FD1152782CFC3B23008955C4 /* SaveDeviceTokenDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveDeviceTokenDTO.swift; sourceTree = "<group>"; };
 		FD119F412CED865000BE22BD /* SelectLocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationViewController.swift; sourceTree = "<group>"; };
 		FD119F452CED867600BE22BD /* ConvertLocationToTextUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvertLocationToTextUseCase.swift; sourceTree = "<group>"; };
 		FD119F472CED872500BE22BD /* RequestLocationAuthUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestLocationAuthUseCase.swift; sourceTree = "<group>"; };
@@ -532,6 +538,7 @@
 		320047A42CF9E2A200D08B6D /* RequestUseCase */ = {
 			isa = PBXGroup;
 			children = (
+				FD1152742CFB9F33008955C4 /* CheckFirstLaunchUseCase.swift */,
 				320047A92CFB1C5300D08B6D /* RequestNotiListUseCase.swift */,
 				FDE768A02CF7872E00B5DE88 /* RequestNotificationAuthUseCase.swift */,
 				A2BD4A002CF7AD4300AC72A7 /* RequestMateInfoUseCase.swift */,
@@ -549,6 +556,7 @@
 		320047A52CF9E33200D08B6D /* SaveUseCase */ = {
 			isa = PBXGroup;
 			children = (
+				FD1152762CFBA083008955C4 /* SaveFirstLaunchUseCase.swift */,
 				A266A25F2CF5CF4A002C2B3A /* CreateAccountUseCase.swift */,
 				FD880B5F2CF432780093BEB9 /* SaveProfileImageUseCase.swift */,
 				3200445D2CE5CA1A00D08B6D /* SaveUserInfoUseCase.swift */,
@@ -649,6 +657,7 @@
 		A2BD49F02CF72A8800AC72A7 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				FD1152782CFC3B23008955C4 /* SaveDeviceTokenDTO.swift */,
 				320047A72CFB0E2500D08B6D /* NotiListDTO.swift */,
 				320047842CF80B2200D08B6D /* MateList.swift */,
 				995D94D12CEDF031005A47BF /* MPCProfileDropDTO.swift */,
@@ -1876,8 +1885,10 @@
 				A2BA1B9A2CF260A50080575A /* MateListRouter.swift in Sources */,
 				320043972CDF493C00D08B6D /* Extension + UIView.swift in Sources */,
 				FD119F4A2CED875F00BE22BD /* RequestUserLocationUseCase.swift in Sources */,
+				FD1152772CFBA089008955C4 /* SaveFirstLaunchUseCase.swift in Sources */,
 				320047A82CFB0E2B00D08B6D /* NotiListDTO.swift in Sources */,
 				995D94AC2CECFA30005A47BF /* RequestMatePresenter.swift in Sources */,
+				FD1152792CFC3B29008955C4 /* SaveDeviceTokenDTO.swift in Sources */,
 				FD0634262CE596B5003C9D6B /* Endpoint.swift in Sources */,
 				320044872CEC85CB00D08B6D /* ProfileView.swift in Sources */,
 				320044502CE595F700D08B6D /* ProfileInputPresenter.swift in Sources */,
@@ -1961,6 +1972,7 @@
 				FD0634312CE62578003C9D6B /* AnyEncodable.swift in Sources */,
 				FDE768962CF7831000B5DE88 /* RegisterDeviceTokenUseCase.swift in Sources */,
 				A23A3B732CF4683F00A58705 /* Mate.swift in Sources */,
+				FD1152752CFB9F44008955C4 /* CheckFirstLaunchUseCase.swift in Sources */,
 				3200441A2CE48A3D00D08B6D /* MPCBroswer.swift in Sources */,
 				A25BE4562CEBB63A00886763 /* SupabaseUser.swift in Sources */,
 				A2BA1B922CF1E8C60080575A /* MateListViewController.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/App/AppDelegate.swift
+++ b/SniffMeet/SniffMeet/Source/App/AppDelegate.swift
@@ -23,13 +23,13 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-        let registerDeviceTokenUseCase = RegisterDeviceTokenUseCaseImpl(keychainManager: KeychainManager.shared)
-        Task {
-            do {
-                try await registerDeviceTokenUseCase.execute(deviceToken: deviceToken)
-            } catch {
-                SNMLogger.error(error.localizedDescription)
-            }
+        let registerDeviceTokenUseCase = RegisterDeviceTokenUseCaseImpl(
+            keychainManager: KeychainManager.shared
+        )
+        do {
+            try registerDeviceTokenUseCase.execute(deviceToken: deviceToken)
+        } catch {
+            SNMLogger.error("device token register \(error.localizedDescription)")
         }
     }
     func application(

--- a/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
@@ -11,6 +11,7 @@ enum Environment {
         static let dogInfo: String = "dogInfo"
         static let expiresAt: String = "expiresAt"
         static let mateList: String = "mateList"
+        static let isFirstLaunch: String = "isFirstLaunch"
     }
 
     enum KeychainKey {

--- a/SniffMeet/SniffMeet/Source/DTO/SaveDeviceTokenDTO.swift
+++ b/SniffMeet/SniffMeet/Source/DTO/SaveDeviceTokenDTO.swift
@@ -1,0 +1,14 @@
+//
+//  SaveDeviceTokenDTO.swift
+//  SniffMeet
+//
+//  Created by sole on 12/1/24.
+//
+
+struct SaveDeviceTokenDTO: Codable {
+    let deviceToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case deviceToken = "device_token"
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Home/Main/HomeModuleBuilder.swift
+++ b/SniffMeet/SniffMeet/Source/Home/Main/HomeModuleBuilder.swift
@@ -15,6 +15,18 @@ enum HomeModuleBuilder {
             loadUserInfoUseCase: LoadUserInfoUseCaseImpl(
                 dataLoadable: LocalDataManager(),
                 imageManageable: SNMFileManager()
+            ),
+            checkFirstLaunchUseCase: CheckFirstLaunchUseCaseImpl(
+                userDefaultsManager: UserDefaultsManager.shared
+            ),
+            saveFirstLaunchUseCase: SaveFirstLaunchUseCaseImpl(
+                userDefaultsManager: UserDefaultsManager.shared
+            ),
+            requestNotificationAuthUseCase: RequestNotificationAuthUseCaseImpl(),
+            remoteSaveDeviceTokenUseCase: RemoteSaveDeviceTokenUseCaseImpl(
+                jsonEncoder: JSONEncoder(),
+                keychainManager: KeychainManager.shared,
+                remoteDBManager: SupabaseDatabaseManager.shared
             )
         )
         view.presenter = HomePresenter(view: view, router: router, interactor: interactor)

--- a/SniffMeet/SniffMeet/Source/Home/Main/Interactor/HomeInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Home/Main/Interactor/HomeInteractor.swift
@@ -43,8 +43,7 @@ final class HomeInteractor: HomeInteractable {
         Task {
             do {
                 try saveFirstLaunchUseCase.execute()
-                let isAllowed = try await requestNotificationAuthUseCase.execute()
-                guard isAllowed else { return }
+                _ = try await requestNotificationAuthUseCase.execute()
                 try await remoteSaveDeviceTokenUseCase.execute()
             } catch {
                 SNMLogger.error(error.localizedDescription)

--- a/SniffMeet/SniffMeet/Source/Home/Main/Interactor/HomeInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Home/Main/Interactor/HomeInteractor.swift
@@ -8,18 +8,47 @@
 protocol HomeInteractable: AnyObject {
     var presenter: (any HomePresentable)? { get }
     func loadInfo() throws -> UserInfo
+    func saveDeviceToken()
 }
 
 final class HomeInteractor: HomeInteractable {
     weak var presenter: (any HomePresentable)?
-    private let loadUserInfoUseCase: LoadUserInfoUseCase
+    private let loadUserInfoUseCase: any LoadUserInfoUseCase
+    private let checkFirstLaunchUseCase: any CheckFirstLaunchUseCase
+    private let saveFirstLaunchUseCase: any SaveFirstLaunchUseCase
+    private let requestNotificationAuthUseCase: any RequestNotificationAuthUseCase
+    private let remoteSaveDeviceTokenUseCase: any RemoteSaveDeviceTokenUseCase
 
-    init(presenter: (any HomePresentable)? = nil, loadUserInfoUseCase: LoadUserInfoUseCase) {
+    init(
+        presenter: (any HomePresentable)? = nil,
+        loadUserInfoUseCase: any LoadUserInfoUseCase,
+        checkFirstLaunchUseCase: any CheckFirstLaunchUseCase,
+        saveFirstLaunchUseCase: any SaveFirstLaunchUseCase,
+        requestNotificationAuthUseCase: any RequestNotificationAuthUseCase,
+        remoteSaveDeviceTokenUseCase: any RemoteSaveDeviceTokenUseCase
+    ) {
         self.presenter = presenter
         self.loadUserInfoUseCase = loadUserInfoUseCase
+        self.checkFirstLaunchUseCase = checkFirstLaunchUseCase
+        self.saveFirstLaunchUseCase = saveFirstLaunchUseCase
+        self.requestNotificationAuthUseCase = requestNotificationAuthUseCase
+        self.remoteSaveDeviceTokenUseCase = remoteSaveDeviceTokenUseCase
     }
 
     func loadInfo() throws -> UserInfo {
         try loadUserInfoUseCase.execute()
+    }
+    func saveDeviceToken() {
+        guard checkFirstLaunchUseCase.execute() else { return }
+        Task {
+            do {
+                try saveFirstLaunchUseCase.execute()
+                let isAllowed = try await requestNotificationAuthUseCase.execute()
+                guard isAllowed else { return }
+                try await remoteSaveDeviceTokenUseCase.execute()
+            } catch {
+                SNMLogger.error(error.localizedDescription)
+            }
+        }
     }
 }

--- a/SniffMeet/SniffMeet/Source/Home/Main/Presenter/HomePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Home/Main/Presenter/HomePresenter.swift
@@ -40,6 +40,7 @@ final class HomePresenter: HomePresentable {
     }
 
     func viewDidLoad() {
+        interactor?.saveDeviceToken()
         do {
             if let dog = try interactor?.loadInfo() {
                 output.dogInfo.send(dog)

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/CheckFirstLaunchUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/CheckFirstLaunchUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  CheckFirstLaunchUseCase.swift
+//  SniffMeet
+//
+//  Created by sole on 12/1/24.
+//
+
+protocol CheckFirstLaunchUseCase {
+    func execute() -> Bool
+}
+
+struct CheckFirstLaunchUseCaseImpl: CheckFirstLaunchUseCase {
+    private let userDefaultsManager: any UserDefaultsManagable
+
+    init(userDefaultsManager: any UserDefaultsManagable) {
+        self.userDefaultsManager = userDefaultsManager
+    }
+
+    func execute() -> Bool {
+        let isFirstLaunch = try? userDefaultsManager.get(
+            forKey: Environment.UserDefaultsKey.isFirstLaunch,
+            type: Bool.self
+        )
+        return isFirstLaunch == nil
+    }
+}

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/RegisterDeviceTokenUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/RegisterDeviceTokenUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol RegisterDeviceTokenUseCase {
-    func execute(deviceToken: Data) async throws
+    func execute(deviceToken: Data) throws
 }
 
 struct RegisterDeviceTokenUseCaseImpl: RegisterDeviceTokenUseCase {
@@ -18,8 +18,7 @@ struct RegisterDeviceTokenUseCaseImpl: RegisterDeviceTokenUseCase {
         self.keychainManager = keychainManager
     }
 
-    func execute(deviceToken: Data) async throws {
-        if let device = try? keychainManager.get(forKey: Environment.KeychainKey.deviceToken) { return }
+    func execute(deviceToken: Data) throws {
         let deviceTokenString = deviceToken.reduce("") { $0 + String(format: "%02X", $1) }
         try keychainManager.set(
             value: deviceTokenString,

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/RemoteSaveDeviceTokenUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/RemoteSaveDeviceTokenUseCase.swift
@@ -12,21 +12,27 @@ protocol RemoteSaveDeviceTokenUseCase {
 }
 
 struct RemoteSaveDeviceTokenUseCaseImpl: RemoteSaveDeviceTokenUseCase {
+    private let jsonEncoder: JSONEncoder
     private let keychainManager: any KeychainManagable
     private let remoteDBManager: any RemoteDatabaseManager
 
     init(
+        jsonEncoder: JSONEncoder,
         keychainManager: any KeychainManagable,
         remoteDBManager: any RemoteDatabaseManager
     ) {
+        self.jsonEncoder = jsonEncoder
         self.keychainManager = keychainManager
         self.remoteDBManager = remoteDBManager
     }
 
     func execute() async throws {
-        let deviceToken = try keychainManager.get(forKey: Environment.KeychainKey.deviceToken
+        let deviceToken = try keychainManager.get(forKey: Environment.KeychainKey.deviceToken)
+        let deviceTokenDTO = SaveDeviceTokenDTO(deviceToken: deviceToken)
+        let deviceTokenData = try jsonEncoder.encode(deviceTokenDTO)
+        try await remoteDBManager.updateData(
+            into: Environment.SupabaseTableName.userInfo,
+            with: deviceTokenData
         )
-        // TODO: DB 확인 필요
-        try await remoteDBManager.insertData(into: "device_token", with: Data(deviceToken.utf8))
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveFirstLaunchUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveFirstLaunchUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  SaveFirstLaunchUseCase.swift
+//  SniffMeet
+//
+//  Created by sole on 12/1/24.
+//
+
+protocol SaveFirstLaunchUseCase {
+    func execute() throws
+}
+
+struct SaveFirstLaunchUseCaseImpl: SaveFirstLaunchUseCase {
+    private let userDefaultsManager: any UserDefaultsManagable
+
+    init(userDefaultsManager: any UserDefaultsManagable) {
+        self.userDefaultsManager = userDefaultsManager
+    }
+
+    func execute() throws {
+        try userDefaultsManager.set(
+            value: true,
+            forKey: Environment.UserDefaultsKey.isFirstLaunch
+        )
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Interactor/RespondWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Interactor/RespondWalkInteractor.swift
@@ -58,10 +58,11 @@ final class RespondWalkInteractor: RespondWalkInteractable {
                     return
                 }
                 presenter?.didFetchUserInfo(senderInfo: senderInfo)
+                guard let profileImageURL = senderInfo.profileImageURL else {return }
+                fetchProfileImage(urlString: profileImageURL)
             } catch {
                 presenter?.didFailToFetchWalkRequest(error: error)
             }
-            fetchProfileImage(urlString: profileImageURL)
         }
     }
     


### PR DESCRIPTION
### 🔖  Issue Number
close #144 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- deivce token을 서버에 저장하는 로직을 구현했습니다. 

플로우는 아래와 같습니다. 

0. HomeViewController가 viewDidLoad 되었을 때 
1. 앱 첫 실행인지 확인: device token은 앱이 다시 설치됐을 때 말고는 갱신될 일이 없어서 첫 실행을 기준으로 잡았습니다. 
2. 앱 첫 실행이라면 알림 권한을 확인 
3. 알림 권한 허용 여부에 상관없이 device token 등록 
처음에는 권한 허용일 때만 등록하려고 했는데, device token이 DB에 없으면 산책 요청 보내는 로직이 서버에서 무조건 실패하도록 설정되어 있습니다. notification list에도 레코드 추가가 안 되더라구요... 그래서 변경했습니다.