### PR TITLE
[fix] 홈 뷰 키워드 정렬 문제 해결

### DIFF
--- a/SniffMeet/SniffMeet/Source/Home/Main/View/ProfileCardView.swift
+++ b/SniffMeet/SniffMeet/Source/Home/Main/View/ProfileCardView.swift
@@ -38,6 +38,7 @@ final class ProfileCardView: UIView {
     private let profileInfoStackView: UIStackView = {
         var stackView = UIStackView()
         stackView.axis = .vertical
+        stackView.alignment = .leading
         stackView.spacing = 12
         return stackView
     }()


### PR DESCRIPTION
- 스택 뷰의 정렬 방식이 fill로 설정되어 있던 것을 leading으로 변경했습니다.

### 🔖  Issue Number

close #136

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- 홈 뷰 키워드 정렬 문제 해결

|전|후|
|----|----|
|<img width="400" alt="Screenshot 2024-12-02 at 3 00 13 AM" src="https://github.com/user-attachments/assets/b79cc51e-ede4-46a3-8fc0-ccb94dff2dbe">|<img width="400" alt="Screenshot 2024-12-02 at 3 00 13 AM" src="https://github.com/user-attachments/assets/7413b35f-f703-434c-aa5d-cbbca87344d3">|


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 스택 뷰 정렬이 잘못되어 있었습니다.

