### PR TITLE
[feat] 메이트 요청 거절 / 수락 기능 구현

### DIFF
--- a/SniffMeet/SniffMeet/Source/DTO/DogProfileDTO.swift
+++ b/SniffMeet/SniffMeet/Source/DTO/DogProfileDTO.swift
@@ -8,13 +8,15 @@
 import Foundation
 
 struct DogProfileDTO: Codable {
+    let id: UUID
     let name: String
     let keywords: [Keyword]
-    let profileImage: Data?
+    var profileImage: Data?
 }
 
 extension DogProfileDTO {
-    static let example: DogProfileDTO = DogProfileDTO(name: "후추",
-                                                        keywords: [.shy],
-                                                        profileImage: nil)
+    static var example: DogProfileDTO = DogProfileDTO(id: UUID(uuidString: "4a8c392f-24af-4fbf-9043-11b4dd4c131b") ?? .init(),
+                                                      name: "두식",
+                                                      keywords: [.energetic, .friendly],
+                                                      profileImage: nil)
 }

--- a/SniffMeet/SniffMeet/Source/Home/Main/Router/HomeRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Home/Main/Router/HomeRouter.swift
@@ -37,7 +37,7 @@ final class HomeRouter: NSObject, HomeRoutable {
     }
     func showMateRequestView(homeView: any HomeViewable, data: DogProfileDTO) {
         guard let homeView = homeView as? UIViewController else { return }
-        let requestMateViewController = RequestMateViewController(profile: data)
+        let requestMateViewController = RequestMateRouter.createRequestMateModule(profile: data)
         requestMateViewController.modalPresentationStyle = .fullScreen
         
         if let homeView = homeView as?  UIViewControllerTransitioningDelegate {

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -136,7 +136,8 @@ final class MPCManager: NSObject {
     }
 
     private func updateProfile(dogInfo: UserInfo) {
-        profile = DogProfileDTO(name: dogInfo.name, keywords: dogInfo.keywords, profileImage: dogInfo.profileImage)
+        guard let userID = SessionManager.shared.session?.user?.userID else { return }
+        profile = DogProfileDTO(id: userID, name: dogInfo.name, keywords: dogInfo.keywords, profileImage: dogInfo.profileImage)
     }
 
     private func sendProfileData(data: Data) {

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/Interactor/RequestMateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/Interactor/RequestMateInteractor.swift
@@ -5,14 +5,31 @@
 //  Created by 배현진 on 11/20/24.
 //
 
+import Foundation
+
 protocol RequestMateInteractable: AnyObject {
+    var presenter: (any RequestMateInteractorOutput)? { get set }
+
     func fetchDogProfile()
+    func saveMateInfo(id: UUID) async
 }
 
 final class RequestMateInteractor: RequestMateInteractable {
-    weak var presenter: RequestMatePresentable?
+    weak var presenter: (any RequestMateInteractorOutput)?
+    private let respondMateRequestUseCase: RespondMateRequestUseCase
+
+    init(
+        presenter: (any RequestMateInteractorOutput)? = nil,
+        respondMateRequestUseCase: RespondMateRequestUseCase
+    ) {
+        self.presenter = presenter
+        self.respondMateRequestUseCase = respondMateRequestUseCase
+    }
 
     func fetchDogProfile() {
         /// 프로필 데이터 가져오고  presenter의 didFetchDogProfile 호출.
+    }
+    func saveMateInfo(id: UUID) async {
+        await respondMateRequestUseCase.execute(mateId: id, isAccepted: true)
     }
 }

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/Presenter/RequestMatePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/Presenter/RequestMatePresenter.swift
@@ -5,9 +5,19 @@
 //  Created by 배현진 on 11/20/24.
 //
 
+import Foundation
+
 protocol RequestMatePresentable: AnyObject {
-    func didFetchDogProfile(_ dogProfile: DogProfileDTO)
-    func viewDidLoad()
+    var view: RequestMateViewable? { get set }
+    var interactor: RequestMateInteractable? { get set }
+    var router: RequestMateRoutable? { get set }
+
+    func closeTheView()
+    func didTapAcceptButton(id: UUID) async
+}
+
+protocol RequestMateInteractorOutput: AnyObject {
+
 }
 
 final class RequestMatePresenter: RequestMatePresentable {
@@ -15,10 +25,27 @@ final class RequestMatePresenter: RequestMatePresentable {
     var interactor: RequestMateInteractable?
     var router: RequestMateRoutable?
 
-    func viewDidLoad() {
-        interactor?.fetchDogProfile()
+    init(
+        view: RequestMateViewable? = nil,
+        interactor: RequestMateInteractable? = nil,
+        router: RequestMateRoutable? = nil
+    ) {
+        self.view = view
+        self.interactor = interactor
+        self.router = router
     }
 
-    func didFetchDogProfile(_ dogProfile: DogProfileDTO) {
+    func closeTheView() {
+        if let view {
+            router?.dismissView(view: view)
+        }
     }
+    func didTapAcceptButton(id: UUID) async {
+        SNMLogger.info("id: \(id)")
+        await interactor?.saveMateInfo(id: id)
+    }
+}
+
+extension RequestMatePresenter: RequestMateInteractorOutput {
+
 }

--- a/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/RequestMate/View/RequestMateViewController.swift
@@ -158,6 +158,7 @@ final class RequestMateViewController: BaseViewController, RequestMateViewable {
             .sink { [weak self] in
                 Task {
                     await self?.presenter?.didTapAcceptButton(id: self?.profile.id ?? DogProfileDTO.example.id)
+                    self?.presenter?.closeTheView()
                 }
             }
             .store(in: &cancellables)

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveUserInfoUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveUserInfoUseCase.swift
@@ -23,6 +23,6 @@ struct SaveUserInfoUseCaseImpl: SaveUserInfoUseCase {
             SNMLogger.error("프로필 이미지 저장 실패: \(error.localizedDescription)")
         }
         
-        try localDataManager.storeData(data: Array<UUID>() , key: Environment.UserDefaultsKey.mateList)
+        try localDataManager.storeData(data: [UUID(uuidString: "23f52fdb-5292-4afb-a8a4-6adb467b39ce")] , key: Environment.UserDefaultsKey.mateList)
     }
 }

--- a/SniffMeet/SniffMeet/Source/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
@@ -48,6 +48,7 @@ extension WalkLogListViewController: UITableViewDataSource {
         // FIXME: 실제 데이터로 변경 필요
         WalkLogCell(
             dogInfo: .init(
+            id: UUID(uuidString: "") ?? DogProfileDTO.example.id,
             name: "후추추",
             keywords: [],
             profileImage: nil


### PR DESCRIPTION
### 🔖  Issue Number

close #167

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] 메이트 요청 수락 버튼 기능 구현
- [x] 메이트 요청 거절 버튼 기능 구현
- [x] 서버에 추가된 메이트 정보 저장하기


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1
프로필 드랍을 하고 그 정보로 메이트 정보를 추가하기 위해서
프로필 드랍에 사용하는 DogProfileDTO에 id(UUID)값 추가했습니다.

- 특이 사항 2
각각 거절과 수락 버튼 누르고 난 후에 모두 홈 화면으로 다시 전환됩니다.
이후에 alert 정도 추가해봐도 좋을 것 같습니다.

### 👻 레퍼런스

