### PR TITLE
[fix] 산책 요청 & 응답 뷰에서 제출 버튼 지연 문제 해결 

### DIFF
--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Interactor/RequestWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Interactor/RequestWalkInteractor.swift
@@ -52,7 +52,12 @@ final class RequestWalkInteractor: RequestWalkInteractable {
                                    senderName: myInfo.name,
                                    category: .walkRequest)
         Task {
-            try await requestWalkUseCase.execute(walkNoti: walkNoti)
+            do {
+                try await requestWalkUseCase.execute(walkNoti: walkNoti)
+
+            } catch {
+                SNMLogger.error("RequestWalkInteractor: \(error.localizedDescription)")
+            }
         }
         presenter?.didSendWalkRequest()
     }

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Interactor/RequestWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Interactor/RequestWalkInteractor.swift
@@ -53,8 +53,8 @@ final class RequestWalkInteractor: RequestWalkInteractable {
                                    category: .walkRequest)
         Task {
             try await requestWalkUseCase.execute(walkNoti: walkNoti)
-            presenter?.didSendWalkRequest()
         }
+        presenter?.didSendWalkRequest()
     }
 
     func requestMateInfo() {

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/View/RequestWalkViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/View/RequestWalkViewController.swift
@@ -16,6 +16,7 @@ final class RequestWalkViewController: BaseViewController, RequestWalkViewable {
     var presenter: RequestWalkPresentable?
     private var cancellables: Set<AnyCancellable> = []
     private var address: Address?
+    private var textViewEdited: Bool = false
     private var dismissButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "xmark"), for: .normal)
@@ -183,7 +184,12 @@ final class RequestWalkViewController: BaseViewController, RequestWalkViewable {
             .store(in: &cancellables)
     }
     func updateSubmitButtonState() {
-        submitButton.isEnabled = (messageTextView.text.isEmpty == false) && (address != nil)
+        if textViewEdited == false {
+            submitButton.isEnabled = false
+        } else {
+            submitButton.isEnabled = (messageTextView.text.isEmpty == false) && (address != nil)
+        }
+        
     }
 }
 
@@ -201,7 +207,7 @@ extension RequestWalkViewController: UITextViewDelegate {
         if textView.text == Context.messagePlaceholder {
             textView.text = nil
             textView.textColor = .black
-            updateSubmitButtonState()
+            textViewEdited = true
         }
     }
     func textViewDidEndEditing(_ textView: UITextView) {

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/View/RequestWalkViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/View/RequestWalkViewController.swift
@@ -62,7 +62,7 @@ final class RequestWalkViewController: BaseViewController, RequestWalkViewable {
     }
     override func configureAttributes() {
         hideKeyboardWhenTappedAround()
-        submitButton.isEnabled = false
+        updateSubmitButtonState()
     }
     override func configureHierachy() {
         [titleLabel,
@@ -140,7 +140,7 @@ final class RequestWalkViewController: BaseViewController, RequestWalkViewable {
                 self?.locationView.setAddress(
                     address: address?.location ?? Context.locationGuideTitle
                 )
-                self?.submitButton.isEnabled = (self?.messageTextView.text.isEmpty == false)
+                self?.updateSubmitButtonState()
             }
             .store(in: &cancellables)
         presenter?.output.profileImageData
@@ -182,6 +182,9 @@ final class RequestWalkViewController: BaseViewController, RequestWalkViewable {
             }
             .store(in: &cancellables)
     }
+    func updateSubmitButtonState() {
+        submitButton.isEnabled = (messageTextView.text.isEmpty == false) && (address != nil)
+    }
 }
 
 private extension RequestWalkViewController {
@@ -198,7 +201,7 @@ extension RequestWalkViewController: UITextViewDelegate {
         if textView.text == Context.messagePlaceholder {
             textView.text = nil
             textView.textColor = .black
-            submitButton.isEnabled = false
+            updateSubmitButtonState()
         }
     }
     func textViewDidEndEditing(_ textView: UITextView) {
@@ -208,7 +211,7 @@ extension RequestWalkViewController: UITextViewDelegate {
         }
     }
     func textViewDidChange(_ textView: UITextView) {
-        submitButton.isEnabled = (!textView.text.isEmpty) && (locationView.locationString != Context.locationGuideTitle)
+        updateSubmitButtonState()
     }
     func textView(
         _ textView: UITextView,

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Interactor/RespondWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Interactor/RespondWalkInteractor.swift
@@ -70,10 +70,8 @@ final class RespondWalkInteractor: RespondWalkInteractable {
         do {
             Task {
                 try await respondWalkRequestUseCase.execute(walkNoti: walkNoti)
-                presenter?.didSendWalkRespond()
             }
-        } catch {
-            presenter?.didFailToSendWalkRequest(error: error)
+            presenter?.didSendWalkRespond()
         }
     }
     


### PR DESCRIPTION
### 🔖  Issue Number

close #178 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  산책 요청 & 응답 뷰에서 제출 버튼 지연 문제 해결 
- [x] 산책 요청 뷰에서 버튼 비활성화 처리하기 


지연 문제가 발생한 이유는 네트워크 요청 작업이 일어난 후에 화면전환이 발생하기 때문이었습니다. 이와 같이 수정한 후에는 dismiss가 바로 이루어집니다!

변경 전
```swift
  do {
            Task {
                try await respondWalkRequestUseCase.execute(walkNoti: walkNoti)
                presenter?.didSendWalkRespond()
            }
        }
```

변경 후
```swift
  do {
            Task {
                try await respondWalkRequestUseCase.execute(walkNoti: walkNoti)
            }
            presenter?.didSendWalkRespond()
        }
```
