### PR TITLE
[feat] TextField 조건 지정

### DIFF
--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
@@ -174,4 +174,24 @@ extension ProfileCreateViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         submitButton.isEnabled = (textField.text?.count ?? 0 > 1)
     }
+
+    func textField(_ textField: UITextField,
+                   shouldChangeCharactersIn range: NSRange,
+                   replacementString string: String) -> Bool {
+        guard let text = textField.text else { return false }
+        let newLength = text.count + string.count - range.length
+
+        UIView.animate(withDuration: 0.2) {
+            if newLength > 8 {
+                self.warningLabel.text = "닉네임은 최대 8글자까지 입력할 수 있습니다."
+                self.warningLabel.alpha = 1
+            } else {
+                self.warningLabel.alpha = 0
+            }
+        }
+        let inputTextValid = newLength <= 15
+
+        return inputTextValid
+    }
+
 }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
@@ -43,7 +43,6 @@ final class ProfileCreateViewController: BaseViewController, ProfileCreateViewab
         let label = UILabel()
         label.textColor = SNMColor.warningRed
         label.text = Context.warning
-        label.alpha = 1
         label.font = UIFont.systemFont(ofSize: 12)
         return label
     }()

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileCreateViewController.swift
@@ -42,8 +42,8 @@ final class ProfileCreateViewController: BaseViewController, ProfileCreateViewab
     private var warningLabel: UILabel = {
         let label = UILabel()
         label.textColor = SNMColor.warningRed
-        label.text = Context.placeholder
-        label.alpha = 0
+        label.text = Context.warning
+        label.alpha = 1
         label.font = UIFont.systemFont(ofSize: 12)
         return label
     }()
@@ -95,6 +95,7 @@ private extension ProfileCreateViewController {
     enum Context {
         static let submitBtnTitle: String = "등록 완료"
         static let placeholder: String = "닉네임을 입력해주세요."
+        static let warning: String = "닉네임은 최대 8글자까지 입력할 수 있습니다."
         static let mainTitle: String = "마지막으로,\n반려견 사진과 닉네임을 등록해주세요."
         static let horizontalPadding: CGFloat = 24
         static let imageViewSize: CGFloat = 140
@@ -140,7 +141,7 @@ private extension ProfileCreateViewController {
             warningLabel.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor,
                                               constant: 16),
             warningLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor,
-                                                  constant: Context.horizontalPadding),
+                                                  constant: 26),
             submitButton.leadingAnchor.constraint(equalTo: view.leadingAnchor,
                                                   constant: Context.horizontalPadding),
             submitButton.trailingAnchor.constraint(equalTo: view.trailingAnchor,
@@ -172,7 +173,8 @@ extension ProfileCreateViewController: PHPickerViewControllerDelegate {
 
 extension ProfileCreateViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        submitButton.isEnabled = (textField.text?.count ?? 0 > 1)
+        guard let textCount = textField.text?.count else { return }
+        submitButton.isEnabled = (textCount > 1 && textCount < 9 )
     }
 
     func textField(_ textField: UITextField,
@@ -180,15 +182,6 @@ extension ProfileCreateViewController: UITextFieldDelegate {
                    replacementString string: String) -> Bool {
         guard let text = textField.text else { return false }
         let newLength = text.count + string.count - range.length
-
-        UIView.animate(withDuration: 0.2) {
-            if newLength > 8 {
-                self.warningLabel.text = "닉네임은 최대 8글자까지 입력할 수 있습니다."
-                self.warningLabel.alpha = 1
-            } else {
-                self.warningLabel.alpha = 0
-            }
-        }
         let inputTextValid = newLength <= 15
 
         return inputTextValid

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileInputViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileInputViewController.swift
@@ -354,6 +354,7 @@ private extension ProfileInputViewController {
                                 for: .editingChanged)
         ageTextField.addTarget(self, action: #selector(textFieldDidChange(_:)),
                                for: .editingChanged)
+        nameTextField.delegate = self
         ageTextField.delegate = self
         ageTextField.keyboardType = .numberPad
     }
@@ -396,11 +397,17 @@ extension ProfileInputViewController: UITextFieldDelegate {
                    shouldChangeCharactersIn range: NSRange,
                    replacementString string: String) -> Bool
     {
-        guard let text = textField.text else { return true }
-        let allowedCharacters = CharacterSet.decimalDigits
-        let inputCharacters = CharacterSet(charactersIn: string)
-        let filteredInputCharacters = allowedCharacters.isSuperset(of: inputCharacters)
-        let newLength = text.count + string.count - range.length
-        return filteredInputCharacters && newLength <= 2
+        if textField == nameTextField, let text = textField.text {
+            let newLength = text.count + string.count - range.length
+            return newLength <= 15
+        }
+        if textField == ageTextField, let text = textField.text {
+            let allowedCharacters = CharacterSet.decimalDigits
+            let inputCharacters = CharacterSet(charactersIn: string)
+            let filteredInputCharacters = allowedCharacters.isSuperset(of: inputCharacters)
+            let newLength = text.count + string.count - range.length
+            return filteredInputCharacters && newLength <= 2
+        }
+        return true
     }
 }

--- a/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileInputViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Auth/CreateProfile/View/ProfileInputViewController.swift
@@ -397,8 +397,10 @@ extension ProfileInputViewController: UITextFieldDelegate {
                    replacementString string: String) -> Bool
     {
         guard let text = textField.text else { return true }
+        let allowedCharacters = CharacterSet.decimalDigits
+        let inputCharacters = CharacterSet(charactersIn: string)
+        let filteredInputCharacters = allowedCharacters.isSuperset(of: inputCharacters)
         let newLength = text.count + string.count - range.length
-        return newLength <= 2
-        
+        return filteredInputCharacters && newLength <= 2
     }
 }

--- a/SniffMeet/SniffMeet/Source/Home/EditProfile/View/ProfileEditViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Home/EditProfile/View/ProfileEditViewController.swift
@@ -247,8 +247,11 @@ extension ProfileEditViewController: UITextFieldDelegate {
                    replacementString string: String) -> Bool
     {
         guard textField == ageTextField, let text = textField.text else { return true }
+        let allowedCharacters = CharacterSet.decimalDigits
+        let inputCharacters = CharacterSet(charactersIn: string)
+        let filteredInputCharacters = allowedCharacters.isSuperset(of: inputCharacters)
         let newLength = text.count + string.count - range.length
-        return newLength <= 2
+        return filteredInputCharacters && newLength <= 2
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/Home/EditProfile/View/ProfileEditViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Home/EditProfile/View/ProfileEditViewController.swift
@@ -246,12 +246,18 @@ extension ProfileEditViewController: UITextFieldDelegate {
                    shouldChangeCharactersIn range: NSRange,
                    replacementString string: String) -> Bool
     {
-        guard textField == ageTextField, let text = textField.text else { return true }
-        let allowedCharacters = CharacterSet.decimalDigits
-        let inputCharacters = CharacterSet(charactersIn: string)
-        let filteredInputCharacters = allowedCharacters.isSuperset(of: inputCharacters)
-        let newLength = text.count + string.count - range.length
-        return filteredInputCharacters && newLength <= 2
+        if textField == nameTextField, let text = textField.text {
+            let newLength = text.count + string.count - range.length
+            return newLength <= 15
+        }
+        if textField == ageTextField, let text = textField.text {
+            let allowedCharacters = CharacterSet.decimalDigits
+            let inputCharacters = CharacterSet(charactersIn: string)
+            let filteredInputCharacters = allowedCharacters.isSuperset(of: inputCharacters)
+            let newLength = text.count + string.count - range.length
+            return filteredInputCharacters && newLength <= 2
+        }
+        return true
     }
 }
 


### PR DESCRIPTION
### 🔖  Issue Number

close #184

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] 나이 입력 뷰에 숫자만 입력하게 하기
- [x] 닉네임 입력 제한 글자수 라벨 보이게 하기

https://github.com/user-attachments/assets/60a94f4e-11b3-41d3-9d40-94c648c23635

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1
글자수 제한에 따른 버튼 활성화 조건을 주었습니다.
그로인해 경고 라벨은 활성화 하는 방식에서 필수 표시 상태로 변경하였습니다.
무제한 입력의 경우를 방지하기 위해서 글자수 제한은 15글자이고, 8글자 초과시 버튼 비활성화됩니다.

- 특이 사항 2
글자 수 제한을 주었을 경우 한글이어서 발생하는 문제가 존재합니다.
마지막 글자가 "과"일 경우 "고" 까지만 입력되도 이후 입력 값을 다음 문자로 인식해 입력되지 못하게 설정합니다.
notificationCenter를 사용해 해결할 수 있지만, 그런 경우 마지막 텍스트를 추후 입력하는 텍스트로 교체해 글자수 제한을 맞추게 됩니다.
따라서 글자수 제한에 대한 결과를 입력 제한 (15글자) / 경고 라벨 / 버튼 비활성화 총 3가지를 이용해 사용자에게 제공하도록 설정했습니다.

### 👻 레퍼런스
