### PR TITLE
[fix] 산책 요청 뷰에서 키보드를 편집할 때 키보드가 올라감에 따라 뷰를 가리는 현상 해결

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		320047B62CFCB8D000D08B6D /* EventConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047B52CFCB8CA00D08B6D /* EventConstant.swift */; };
 		320047B92CFD367300D08B6D /* PushNotificationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047B82CFD366E00D08B6D /* PushNotificationConfig.swift */; };
 		320047BB2CFD368100D08B6D /* PushNotificationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047BA2CFD367E00D08B6D /* PushNotificationRequest.swift */; };
+		320047DE2CFE9E0400D08B6D /* Extension + UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */; };
 		9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */; };
 		993736422CFCACB100E3DD58 /* UpdateUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */; };
 		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
@@ -292,6 +293,7 @@
 		320047B52CFCB8CA00D08B6D /* EventConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventConstant.swift; sourceTree = "<group>"; };
 		320047B82CFD366E00D08B6D /* PushNotificationConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationConfig.swift; sourceTree = "<group>"; };
 		320047BA2CFD367E00D08B6D /* PushNotificationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRequest.swift; sourceTree = "<group>"; };
+		320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIApplication.swift"; sourceTree = "<group>"; };
 		9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUserInfoRemoteUseCase.swift; sourceTree = "<group>"; };
 		993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserInfoUseCase.swift; sourceTree = "<group>"; };
 		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
@@ -1628,6 +1630,7 @@
 		FDE768872CF7811400B5DE88 /* Helper */ = {
 			isa = PBXGroup;
 			children = (
+				320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */,
 				FD8020FD2CF8C8DA0089B349 /* Extension + UIImage.swift */,
 				FDE7689E2CF7858D00B5DE88 /* Extension + UIViewController.swift */,
 				FDE768912CF7828600B5DE88 /* AnyJSONSerializable.swift */,
@@ -1959,6 +1962,7 @@
 				FD880B622CF433AF0093BEB9 /* Environment.swift in Sources */,
 				320043922CDF3D7F00D08B6D /* InputTextField.swift in Sources */,
 				FD119F482CED872C00BE22BD /* RequestLocationAuthUseCase.swift in Sources */,
+				320047DE2CFE9E0400D08B6D /* Extension + UIApplication.swift in Sources */,
 				A2BA1BAC2CF34A860080575A /* RequestProfileImageUseCase.swift in Sources */,
 				FD331A502CF235C400F39426 /* WalkLogPageViewController.swift in Sources */,
 				FD119F422CED865B00BE22BD /* SelectLocationViewController.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Common/Helper/Extension + UIApplication.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Helper/Extension + UIApplication.swift
@@ -1,0 +1,24 @@
+//
+//  Extension + UIAplplication.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 12/3/24.
+//
+import UIKit
+
+extension UIApplication {
+  static var screenSize: CGSize {
+    guard let windowScene = shared.connectedScenes.first as? UIWindowScene else {
+      return UIScreen.main.bounds.size
+    }
+    return windowScene.screen.bounds.size
+  }
+  
+  static var screenHeight: CGFloat {
+    return screenSize.height
+  }
+  
+  static var screenWidth: CGFloat {
+    return screenSize.width
+  }
+}

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/View/RequestWalkViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/View/RequestWalkViewController.swift
@@ -16,6 +16,9 @@ final class RequestWalkViewController: BaseViewController, RequestWalkViewable {
     var presenter: RequestWalkPresentable?
     private var cancellables: Set<AnyCancellable> = []
     private var address: Address?
+    
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
     private var dismissButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "xmark"), for: .normal)
@@ -59,39 +62,73 @@ final class RequestWalkViewController: BaseViewController, RequestWalkViewable {
         messageTextView.delegate = self
         view.backgroundColor = .systemBackground
         presenter?.viewDidLoad()
+        scrollView.delegate = self
+
     }
     override func configureAttributes() {
         hideKeyboardWhenTappedAround()
         submitButton.isEnabled = false
     }
     override func configureHierachy() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+        
+        [scrollView, contentView].forEach{
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
         [titleLabel,
          dismissButton,
          profileView,
          locationView,
          messageTextView,
          submitButton].forEach{
-            view.addSubview($0)
+            contentView.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
     }
     override func configureConstraints() {
+        scrollView.keyboardLayoutGuide.followsUndockedKeyboard = true
+        setScrollViewConstraint()
+        setInsideScrollViewConstraints()
+    }
+    
+    func setScrollViewConstraint() {
         NSLayoutConstraint.activate([
-            titleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            titleLabel.topAnchor.constraint(equalTo: view.topAnchor,
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
+            contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo:
+                                                    scrollView.contentLayoutGuide.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo:
+                                                    scrollView.contentLayoutGuide.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo:
+                                                    scrollView.contentLayoutGuide.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+            contentView.heightAnchor.constraint(
+                equalToConstant: max(650, UIApplication.screenHeight * 0.8))
+        ])
+    }
+    func setInsideScrollViewConstraints() {
+        NSLayoutConstraint.activate([
+            titleLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor,
                                             constant: LayoutConstant.xlargeVerticalPadding),
+            titleLabel.heightAnchor.constraint(equalToConstant: 20),
 
-            dismissButton.topAnchor.constraint(equalTo: view.topAnchor,
+            dismissButton.topAnchor.constraint(equalTo: contentView.topAnchor,
                                                constant: LayoutConstant.regularVerticalPadding),
             dismissButton.trailingAnchor.constraint(
-                equalTo: view.trailingAnchor,
+                equalTo: contentView.trailingAnchor,
                 constant: -LayoutConstant.smallHorizontalPadding),
             dismissButton.heightAnchor.constraint(equalToConstant: LayoutConstant.iconSize),
             dismissButton.widthAnchor.constraint(equalToConstant: LayoutConstant.iconSize),
 
             profileView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
-            profileView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            profileView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.4),
+            profileView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            profileView.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.4),
             profileView.widthAnchor.constraint(equalTo: profileView.heightAnchor),
 
             locationView.topAnchor.constraint(
@@ -101,21 +138,19 @@ final class RequestWalkViewController: BaseViewController, RequestWalkViewable {
                 equalTo: messageTextView.topAnchor,
                 constant: -LayoutConstant.regularVerticalPadding),
             locationView.heightAnchor.constraint(equalToConstant: 25),
+            messageTextView.heightAnchor.constraint(equalToConstant: 140),
 
-            messageTextView.bottomAnchor.constraint(
-                equalTo: submitButton.topAnchor,
-                constant: -LayoutConstant.xlargeVerticalPadding),
-
-            submitButton.bottomAnchor.constraint(equalTo: view.bottomAnchor,
-                                                 constant: -LayoutConstant.xlargeVerticalPadding)
+            submitButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor,
+                                                 constant: -LayoutConstant.xlargeVerticalPadding),
+            submitButton.heightAnchor.constraint(equalToConstant: 51)
         ])
-
+        
         [locationView, messageTextView, submitButton].forEach {
             $0.leadingAnchor.constraint(
-                equalTo: view.leadingAnchor,
+                equalTo: contentView.leadingAnchor,
                 constant: LayoutConstant.smallHorizontalPadding).isActive = true
             $0.trailingAnchor.constraint(
-                equalTo: view.trailingAnchor,
+                equalTo: contentView.trailingAnchor,
                 constant: -LayoutConstant.smallHorizontalPadding).isActive = true
         }
     }
@@ -195,6 +230,11 @@ private extension RequestWalkViewController {
 
 extension RequestWalkViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
+        Task {
+               try? await Task.sleep(nanoseconds: 50_000_000) // 50ms (0.05초)
+            scrollView.scrollRectToVisible(textView.frame, animated: true)
+           }
+
         if textView.text == Context.messagePlaceholder {
             textView.text = nil
             textView.textColor = .black
@@ -208,7 +248,8 @@ extension RequestWalkViewController: UITextViewDelegate {
         }
     }
     func textViewDidChange(_ textView: UITextView) {
-        submitButton.isEnabled = (!textView.text.isEmpty) && (locationView.locationString != Context.locationGuideTitle)
+        submitButton.isEnabled = (!textView.text.isEmpty) &&
+        (locationView.locationString != Context.locationGuideTitle)
     }
     func textView(
         _ textView: UITextView,

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/View/RequestWalkViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/View/RequestWalkViewController.swift
@@ -230,10 +230,10 @@ private extension RequestWalkViewController {
 
 extension RequestWalkViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
-        Task {
-               try? await Task.sleep(nanoseconds: 50_000_000) // 50ms (0.05초)
-            scrollView.scrollRectToVisible(textView.frame, animated: true)
-           }
+        Task {[weak self] in
+            try? await Task.sleep(nanoseconds: 10_000_000) // 50ms (0.05초)
+            self?.scrollView.scrollRectToVisible(textView.frame, animated: true)
+        }
 
         if textView.text == Context.messagePlaceholder {
             textView.text = nil


### PR DESCRIPTION
### 🔖  Issue Number

close #185

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  산책 요청 뷰 Scrollview 추가 
- [x] textviewDidBeginEditing에 텍스트 뷰로 스크롤 이동하는 로직 구현 


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1
현재 0.5초 뒤에 scroll이 textview가 있는 쪽으로 이동합니다. 0.5초 후에 실행하지 않고 바로 실행되면  `scrollView.scrollRectToVisible(textView.frame, animated: true)` 이 로직이 실행되도 화면에 변화가 없더라구요. 

textViewDidBeginEditing 메서드가 호출 뒤에 키보드가 나타나서 이런 현상이 발생하는 거 같습니다. 
즉 이미 화면에 textview가 있는 쪽으로 scroll이 위치해있으므로 실행이 되지 않는거죠. 그래서 0.5초 뒤 (키보드가 올라가는 충분한 시간) 스크롤하라는 로직을 실행하면 제대로 동작되는걸 확인했습니다. 

```swift
func textViewDidBeginEditing(_ textView: UITextView) {
        Task {
               try? await Task.sleep(nanoseconds: 50_000_000) // 50ms (0.05초)
            scrollView.scrollRectToVisible(textView.frame, animated: true)
           }
}
```

https://github.com/user-attachments/assets/c95960a4-b440-4c14-95e1-69c4b3bce619


