### PR TITLE
[fix] 위치 권한을 처음 받아왔을 때 유저의 위치를 제대로 표시하지 못하는 현상 해결 

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -1528,7 +1528,6 @@
 		FDA491932CDA7C6200A36FB0 /* RequestWalk */ = {
 			isa = PBXGroup;
 			children = (
-				FD119F512CED880A00BE22BD /* SelectLocationModuleBuildable.swift */,
 				320044692CEB182400D08B6D /* View */,
 				FDA491952CDA7C6A00A36FB0 /* Interactor */,
 				FDA491962CDA7C6A00A36FB0 /* Presenter */,
@@ -1558,6 +1557,7 @@
 		FDA491982CDA7C6A00A36FB0 /* Router */ = {
 			isa = PBXGroup;
 			children = (
+				FD119F512CED880A00BE22BD /* SelectLocationModuleBuildable.swift */,
 				320044742CEB4D6200D08B6D /* RequestWalkRouter.swift */,
 				FD119F4F2CED87DD00BE22BD /* SelectLocationRouter.swift */,
 			);

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestLocationAuthUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestLocationAuthUseCase.swift
@@ -8,7 +8,7 @@
 import CoreLocation
 
 protocol RequestLocationAuthUseCase {
-    func execute() throws
+    func execute()
 }
 
 struct RequestLocationAuthUseCaseImpl: RequestLocationAuthUseCase {
@@ -18,24 +18,7 @@ struct RequestLocationAuthUseCaseImpl: RequestLocationAuthUseCase {
         self.locationManager = locationManager
     }
     
-    func execute() throws {
-        switch locationManager.authorizationStatus {
-        case .notDetermined:
-            locationManager.requestWhenInUseAuthorization()
-        case .restricted:
-            throw LocationManagerError.authorizationRestricted
-        case .denied:
-            throw LocationManagerError.authorizationDenied
-        case .authorizedAlways,
-                .authorizedWhenInUse:
-            break
-        @unknown default:
-            locationManager.requestWhenInUseAuthorization()
-        }
+    func execute() {
+        locationManager.requestWhenInUseAuthorization()
     }
-}
-
-enum LocationManagerError: Error {
-    case authorizationDenied
-    case authorizationRestricted
 }

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Interactor/SelectLocationInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Interactor/SelectLocationInteractor.swift
@@ -7,9 +7,8 @@
 
 protocol SelectLocationInteractable: AnyObject {
     var presenter: SelectLocationInteractorOutput? { get set }
-    
-    func requestLocationAuth()
-    func requestUserLocation()
+
+    func requestUserLocationAuth()
     func convertLocationToText(latitude: Double, longtitude: Double)
 }
 
@@ -17,39 +16,26 @@ final class SelectLocationInteractor: SelectLocationInteractable {
     weak var presenter: (any SelectLocationInteractorOutput)?
     private let convertLocationToTextUseCase: any ConvertLocationToTextUseCase
     private let requestLocationAuthUseCase: any RequestLocationAuthUseCase
-    private let requestUserLocationUseCase: any RequestUserLocationUseCase
 
     init(
         presenter: (any SelectLocationInteractorOutput)? = nil,
         convertLocationToTextUseCase: any ConvertLocationToTextUseCase,
-        requestLocationAuthUseCase: any RequestLocationAuthUseCase,
-        requestUserLocationUseCase: any RequestUserLocationUseCase
+        requestLocationAuthUseCase: any RequestLocationAuthUseCase
     ) {
         self.presenter = presenter
         self.convertLocationToTextUseCase = convertLocationToTextUseCase
         self.requestLocationAuthUseCase = requestLocationAuthUseCase
-        self.requestUserLocationUseCase = requestUserLocationUseCase
     }
 
-    func requestLocationAuth() {
-        do {
-            try requestLocationAuthUseCase.execute()
-            presenter?.didSuccessRequestLocationAuth()
-        } catch {
-            presenter?.didFailToRequestLocationAuth(error: error)
-        }
-    }
-    func requestUserLocation() {
-        if let userLocation = requestUserLocationUseCase.execute() {
-            presenter?.didUpdateUserLocation(location: userLocation)
-        }
+    func requestUserLocationAuth() {
+        requestLocationAuthUseCase.execute()
     }
     func convertLocationToText(latitude: Double, longtitude: Double) {
         Task {
             let locationText: String? = await convertLocationToTextUseCase.execute(
                 latitude: latitude, longtitude: longtitude
             )
-             presenter?.didConvertLocationToText(with: locationText)
+            presenter?.didConvertLocationToText(with: locationText)
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Presenter/SelectLocationPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Presenter/SelectLocationPresenter.swift
@@ -17,20 +17,19 @@ protocol SelectLocationPresentable: AnyObject {
     func viewDidLoad()
     func didTapSelectCompleteButton()
     func didUpdateSelectLocation(location: CLLocation)
+    func didUpdateUserLocation(location: CLLocation)
+    func didFailToRequestLocationAuth()
 }
 
 protocol SelectLocationInteractorOutput: AnyObject {
     func didConvertLocationToText(with: String?)
-    func didSuccessRequestLocationAuth()
-    func didFailToRequestLocationAuth(error: any Error)
-    func didUpdateUserLocation(location: CLLocation)
 }
 
 final class SelectLocationPresenter: SelectLocationPresentable {
     weak var view: (any SelectLocationViewable)?
     var interactor: (any SelectLocationInteractable)?
     var router: (any SelectLocationRoutable)?
-    let output: any SelectLocationPresenterOutput
+    var output: any SelectLocationPresenterOutput
 
     init(
         view: (any SelectLocationViewable)? = nil,
@@ -38,7 +37,7 @@ final class SelectLocationPresenter: SelectLocationPresentable {
             selectedCoordinate: CLLocation(latitude: 37.334886, longitude: -122.008988),
             locationLabel: CurrentValueSubject<String?, Never>(nil),
             userLocation: CurrentValueSubject<CLLocation, Never>(
-                CLLocation(latitude: 37.334886, longitude: -122.008988) // default location
+                CLLocation(latitude: 37.334886, longitude: -122.008988)
             )
         )
     ) {
@@ -47,15 +46,7 @@ final class SelectLocationPresenter: SelectLocationPresentable {
     }
 
     func viewDidLoad() {
-        interactor?.requestLocationAuth()
-        let location = output.userLocation.value
-        interactor?.convertLocationToText(
-            latitude: location.coordinate.latitude,
-            longtitude: location.coordinate.longitude
-        )
-    }
-    func didTapFocusUserLocationButton() {
-        interactor?.requestUserLocation()
+        interactor?.requestUserLocationAuth()
     }
     func didTapSelectCompleteButton() {
         guard let view else { return }
@@ -67,9 +58,18 @@ final class SelectLocationPresenter: SelectLocationPresentable {
         router?.dismiss(from: view, with: address)
     }
     func didUpdateSelectLocation(location: CLLocation) {
+        output.selectedCoordinate = location
         interactor?.convertLocationToText(
             latitude: location.coordinate.latitude,
             longtitude: location.coordinate.longitude
+        )
+    }
+    func didFailToRequestLocationAuth() {
+        guard let view else { return }
+        router?.showAlert(
+            from: view,
+            title: "위치 권한 거부",
+            message: "유저 근처 위치를 받아올 수 없습니다. 설정에서 GPS를 허용해주세요."
         )
     }
     func didUpdateUserLocation(location: CLLocation) {
@@ -83,23 +83,12 @@ extension SelectLocationPresenter: SelectLocationInteractorOutput {
     func didConvertLocationToText(with locationText: String?) {
         output.locationLabel.send(locationText)
     }
-    func didSuccessRequestLocationAuth() {
-        interactor?.requestUserLocation()
-    }
-    func didFailToRequestLocationAuth(error: any Error) {
-        guard let view else { return }
-        router?.showAlert(
-            from: view,
-            title: "위치 권한 거부",
-            message: "유저 근처 위치를 받아올 수 없습니다. 설정에서 GPS를 허용해주세요."
-        )
-    }
 }
 
 // MARK: - SelectLocationPresenterOutput
 
 protocol SelectLocationPresenterOutput {
-    var selectedCoordinate: CLLocation { get }
+    var selectedCoordinate: CLLocation { get set }
     var locationLabel: CurrentValueSubject<String?, Never> { get }
     var userLocation: CurrentValueSubject<CLLocation, Never> { get }
 }

--- a/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Router/SelectLocationModuleBuildable.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RequestWalk/Router/SelectLocationModuleBuildable.swift
@@ -20,12 +20,9 @@ extension SelectLocationModuleBuildable {
             convertLocationToTextUseCase: ConvertLocationToTextUseCaseImpl(),
             requestLocationAuthUseCase: RequestLocationAuthUseCaseImpl(
                 locationManager: locationManager
-            ),
-            requestUserLocationUseCase: RequestUserLocationUseCaseImpl(
-                locationManager: locationManager
             )
         )
-        let presenter: SelectLocationPresentable & SelectLocationInteractorOutput = SelectLocationPresenter()
+        let presenter = SelectLocationPresenter()
         let router: SelectLocationRoutable = SelectLocationRouter()
 
         view.presenter = presenter


### PR DESCRIPTION
### 🔖  Issue Number

close #176 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 

- 사용하지 않는 UseCase를 인터랙터에서 제거했습니다. 
유저의 위치 권한만 있으면 mapView의 delegate를 통해 유저 위치를 tracking할 수 있더라구요. 
interactor에 있던 위치 관련 모든 유즈케이스를 제거했습니다. 
interactor는 유저에게 위치 권한 요청만 날려주는 역할을 합니다. 

유저 위치 추적 로직은 아래 코드로 대체됩니다. 
``` swift 
// SelectLocationViewController 
    func mapView(_ mapView: MKMapView, didUpdate userLocation: MKUserLocation) {
        guard let location = userLocation.location else { return }
        presenter?.didUpdateUserLocation(location: location)
    }
    func mapView(_ mapView: MKMapView, didFailToLocateUserWithError error: any Error) {
        guard let location = presenter?.output.userLocation.value else { return }
        updateFocusWithUserLoaction(location: location)
        presenter?.didFailToRequestLocationAuth()
    }
```

- 위치 권한이 승인된 경우 유저 위치로 이동 

<img src="https://github.com/user-attachments/assets/b557ce65-be56-4734-ae63-bdabfd47175c" height=300>

- 위치 권한이 거부된 경우 default 위치로 이동 

<img src="https://github.com/user-attachments/assets/b1eeb6d4-c702-4a56-8a13-183bd5503204" height=300>

