### PR TITLE
[fix] 온보딩 뷰 레이아웃 수정

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -62,8 +62,8 @@
 		320047BB2CFD368100D08B6D /* PushNotificationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047BA2CFD367E00D08B6D /* PushNotificationRequest.swift */; };
 		320047BE2CFDE37300D08B6D /* WalkRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047BD2CFDE36C00D08B6D /* WalkRequestDTO.swift */; };
 		320047DE2CFE9E0400D08B6D /* Extension + UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */; };
-		9919104F2CFF552C008F86D6 /* OnBoardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */; };
 		3200480C2CFF0FB400D08B6D /* ProfileDropAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200480B2CFF0FA600D08B6D /* ProfileDropAnimation.swift */; };
+		9919104F2CFF552C008F86D6 /* OnBoardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */; };
 		9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */; };
 		993736422CFCACB100E3DD58 /* UpdateUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */; };
 		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
@@ -301,8 +301,8 @@
 		320047BA2CFD367E00D08B6D /* PushNotificationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRequest.swift; sourceTree = "<group>"; };
 		320047BD2CFDE36C00D08B6D /* WalkRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkRequestDTO.swift; sourceTree = "<group>"; };
 		320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIApplication.swift"; sourceTree = "<group>"; };
-		9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingPage.swift; sourceTree = "<group>"; };
 		3200480B2CFF0FA600D08B6D /* ProfileDropAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDropAnimation.swift; sourceTree = "<group>"; };
+		9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingPage.swift; sourceTree = "<group>"; };
 		9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUserInfoRemoteUseCase.swift; sourceTree = "<group>"; };
 		993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserInfoUseCase.swift; sourceTree = "<group>"; };
 		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };

--- a/SniffMeet/SniffMeet/Source/OnBoarding/MainBoarding/View/OnBoardingPageViewController.swift
+++ b/SniffMeet/SniffMeet/Source/OnBoarding/MainBoarding/View/OnBoardingPageViewController.swift
@@ -35,7 +35,6 @@ class OnBoardingPageViewController: BaseViewController {
     private var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.spacing = 32
         stackView.alignment = .center
         return stackView
     }()
@@ -46,8 +45,11 @@ class OnBoardingPageViewController: BaseViewController {
     }
     
     override func configureAttributes() {
-        let highlightText = "산책 메이트"
-        titleLabel.attributedText = getAttributedText(fullText: page.title, highlight: highlightText, color: SNMColor.mainBrown)
+        titleLabel.attributedText = getAttributedText(
+            fullText: page.title,
+            highlight: Context.highlightText,
+            color: SNMColor.mainBrown
+        )
         descriptionLabel.text = page.description
         if page.isGif {
             if let gifImageView = createGIFImageView(named: page.imageName) {
@@ -66,6 +68,8 @@ class OnBoardingPageViewController: BaseViewController {
             $0.translatesAutoresizingMaskIntoConstraints = false
             stackView.addArrangedSubview($0)
         }
+        stackView.setCustomSpacing(Context.smallStackSpacing, after: titleLabel)
+        stackView.setCustomSpacing(Context.largeStackSpacing, after: imageView)
 
         stackView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(stackView)
@@ -73,13 +77,29 @@ class OnBoardingPageViewController: BaseViewController {
     }
     override func configureConstraints() {
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: view.topAnchor, constant: 150),
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -200),
-//            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            stackView.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: LayoutConstant.horizontalPadding
+            ),
+            stackView.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -LayoutConstant.horizontalPadding
+            ),
+            stackView.centerYAnchor.constraint(
+                equalTo: view.centerYAnchor,
+                constant: -Context.stackCenter
+            ),
+            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            stackView.heightAnchor.constraint(
+                equalTo: view.heightAnchor,
+                multiplier: Context.multiplier
+            ),
+            stackView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
 
-            imageView.heightAnchor.constraint(equalTo: stackView.widthAnchor, multiplier: 0.7),
+            imageView.heightAnchor.constraint(
+                equalTo: stackView.widthAnchor,
+                multiplier: Context.multiplier
+            ),
             imageView.widthAnchor.constraint(equalTo: stackView.widthAnchor)
         ])
     }
@@ -90,6 +110,11 @@ private extension OnBoardingPageViewController {
     enum Context {
         static let titleLabel: String = "온보딩 타이틀"
         static let descriptionLabel: String = "온보딩 설명"
+        static let highlightText: String = "산책 메이트"
+        static let smallStackSpacing: CGFloat = 10
+        static let largeStackSpacing: CGFloat = 50
+        static let stackCenter: CGFloat = 60
+        static let multiplier: Double = 0.7
     }
 }
 
@@ -123,7 +148,10 @@ private extension OnBoardingPageViewController {
         return imageView
     }
 
-    private func getAttributedText(fullText: String, highlight: String, color: UIColor) -> NSAttributedString {
+    private func getAttributedText(
+        fullText: String,
+        highlight: String,
+        color: UIColor) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(string: fullText)
 
         if let range = fullText.range(of: highlight) {

--- a/SniffMeet/SniffMeet/Source/OnBoarding/MainBoarding/View/OnBoardingViewController.swift
+++ b/SniffMeet/SniffMeet/Source/OnBoarding/MainBoarding/View/OnBoardingViewController.swift
@@ -46,12 +46,30 @@ class OnBoardingViewController: BaseViewController, OnBoardingViewable {
     }
     override func configureConstraints() {
         NSLayoutConstraint.activate([
-            skipButtoon.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
-            skipButtoon.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            skipButtoon.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            pageControl.bottomAnchor.constraint(equalTo: skipButtoon.topAnchor, constant: -30),
-            pageControl.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            pageControl.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            skipButtoon.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -LayoutConstant.horizontalPadding
+            ),
+            skipButtoon.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: LayoutConstant.horizontalPadding
+            ),
+            skipButtoon.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -LayoutConstant.horizontalPadding
+            ),
+            pageControl.bottomAnchor.constraint(
+                equalTo: skipButtoon.topAnchor,
+                constant: -10
+            ),
+            pageControl.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: LayoutConstant.horizontalPadding
+            ),
+            pageControl.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -LayoutConstant.horizontalPadding
+            ),
             pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
     }


### PR DESCRIPTION
### 🔖  Issue Number

close #188

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] 온보딩 뷰 레이아웃이 기기 종류 관계없이 유지되도록 수정

https://github.com/user-attachments/assets/28d96b1e-506a-407e-bb95-05775d2e30ee


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 

기존 레이아웃 구성으로는 se 기기에서 label 깨짐 현상이 발생했습니다.
레이아웃을 stackView로 구현했는데, stackView의 크기가 se 화면 구성 대비 너무 커서
일부분이 잘리는 것이었습니다. multiplier 이용해 비율로 stackView 크기 지정해 해결하였습니다.

### 👻 레퍼런스

