### PR TITLE
[fix]  메이트 목록 테이블 뷰 셀 프로필 이미지 미스매칭 수정

### DIFF
--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
@@ -11,7 +11,7 @@ protocol MateListInteractable: AnyObject {
     var presenter: MateListInteractorOutput? { get set }
 
     func requestMateList(userID: UUID)
-    func requestProfileImage(index: Int, imageName: String?)
+    func requestProfileImage(id: UUID, imageName: String?)
 }
 
 final class MateListInteractor: MateListInteractable {
@@ -36,10 +36,10 @@ final class MateListInteractor: MateListInteractable {
         }
     }
 
-    func requestProfileImage(index: Int, imageName: String?) {
+    func requestProfileImage(id: UUID, imageName: String?) {
         Task { @MainActor in
             let imageData = try await requestProfileImageUseCase.execute(fileName: imageName ?? "")
-            presenter?.didFetchProfileImage(index: index, imageData: imageData)
+            presenter?.didFetchProfileImage(id: id, imageData: imageData)
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Presenter/MateListPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Presenter/MateListPresenter.swift
@@ -15,7 +15,7 @@ protocol MateListPresentable: AnyObject {
     var output: any MateListPresenterOutput { get }
     
     func viewWillAppear()
-    func didTableViewCellLoad(index: Int, imageName: String?)
+    func didTableViewCellLoad(mateID: UUID, imageName: String?)
     func didTabAccessoryButton(mate: Mate)
     func changeIsPaired(with isPaired: Bool)
     func profileData(_ data: DogProfileDTO)
@@ -23,7 +23,7 @@ protocol MateListPresentable: AnyObject {
 
 protocol MateListInteractorOutput: AnyObject {
     func didFetchMateList(mateList: [Mate])
-    func didFetchProfileImage(index: Int, imageData: Data?)
+    func didFetchProfileImage(id: UUID, imageData: Data?)
 }
 
 final class MateListPresenter: MateListPresentable {
@@ -52,8 +52,8 @@ final class MateListPresenter: MateListPresentable {
         SNMLogger.info("메이트 리스트 호출")
     }
 
-    func didTableViewCellLoad(index: Int, imageName: String?) {
-        interactor?.requestProfileImage(index: index, imageName: imageName)
+    func didTableViewCellLoad(mateID: UUID, imageName: String?) {
+        interactor?.requestProfileImage(id: mateID, imageName: imageName)
     }
 
     func didTabAccessoryButton(mate: Mate) {
@@ -89,9 +89,9 @@ extension MateListPresenter: MateListInteractorOutput {
         output.mates.send(mateList)
     }
 
-    func didFetchProfileImage(index: Int, imageData: Data?) {
+    func didFetchProfileImage(id: UUID, imageData: Data?) {
         guard let imageData else { return }
-        output.profileImageData.send((index, imageData))
+        output.profileImageData.send((id, imageData))
     }
 }
 
@@ -99,10 +99,10 @@ extension MateListPresenter: MateListInteractorOutput {
 
 protocol MateListPresenterOutput {
     var mates: CurrentValueSubject<[Mate], Never> { get }
-    var profileImageData: PassthroughSubject<(Int, Data?), Never> { get }
+    var profileImageData: PassthroughSubject<(UUID, Data?), Never> { get }
 }
 
 struct DefaultMateListPresenterOutput: MateListPresenterOutput {
     var mates = CurrentValueSubject<[Mate], Never>([])
-    var profileImageData = PassthroughSubject<(Int, Data?), Never>()
+    var profileImageData = PassthroughSubject<(UUID, Data?), Never>()
 }

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
@@ -14,7 +14,7 @@ protocol MateListViewable: AnyObject {
 
 final class MateListViewController: BaseViewController, MateListViewable {
     var presenter: (any MateListPresentable)?
-    var imageDataSource: [Int: Data] = [:]
+    var imageDataSource: [UUID: Data] = [:]
     private var cancellables: Set<AnyCancellable> = []
     private let tableView: UITableView = UITableView()
     private let addMateButton = AddMateButton(title: "친구를 만들어봐요")
@@ -80,8 +80,11 @@ final class MateListViewController: BaseViewController, MateListViewable {
             .store(in: &cancellables)
         presenter?.output.profileImageData
             .receive(on: RunLoop.main)
-            .sink { [weak self] (index, imageData) in
-                self?.imageDataSource[index] = imageData
+            .sink { [weak self] (mateID, imageData) in
+                self?.imageDataSource[mateID] = imageData
+                guard let index = self?.presenter?.output.mates.value.firstIndex(where: {
+                    $0.userID == mateID
+                }) else { return }
                 let indexPath = IndexPath(item: index, section: 0)
                 self?.tableView.reloadRows(at: [indexPath], with: .none)
             }
@@ -160,17 +163,18 @@ extension MateListViewController: UITableViewDelegate, UITableViewDataSource {
             withIdentifier: Identifier.mateCellID,
             for: indexPath
         )
+        guard let mate = presenter?.output.mates.value[indexPath.row] else { return cell }
         var content = cell.defaultContentConfiguration()
         content.image = .app
-        if let imageData = imageDataSource[indexPath.row] {
+        if let imageData = imageDataSource[mate.userID] {
             var profileImage = UIImage(data: imageData)
             profileImage = profileImage?.clipToSquareWithBackgroundColor(
                 with: ItemSize.profileImageSize.width)
             content.image = profileImage
         } else {
             presenter?.didTableViewCellLoad(
-                index: indexPath.row,
-                imageName: presenter?.output.mates.value[indexPath.row].profileImageURLString
+                mateID: mate.userID,
+                imageName: mate.profileImageURLString
             )
         }
         content.imageProperties.maximumSize = ItemSize.profileImageSize


### PR DESCRIPTION
### 🔖  Issue Number

close #205 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [X] 메이트 목록 테이블 뷰 셀이 본인에 맞는 이미지를 가질 수 있도록 수정  
    - `ImageDataSource` 딕셔너리의 key 타입을 `Int`에서 `UUID`로 변경
    - `UUID`를 기반으로 `IndexPath`를 만드는 로직 추가

https://github.com/user-attachments/assets/43863a3c-1f46-4b21-915c-25c64d7897b9

기존 플로우
`MateListViewController` 로드
- `viewWillAppear` 시점에 메이트 목록 가져옴
- 테이블 뷰 업데이트 (리로드)
    - 리로드 하면서 각각의 사진에 대해 인덱스 기반으로 네트워크에 요청
    - 응답은 <인덱스, 사진 데이터> 형태의 딕셔너리 `ImageDataSource`에 저장됨
    - 응답이 오면 각각의 인덱스에 맞는 셀에 사진 삽입

기존 플로우의 문제점
메이트의 인덱스가 변했을 때(메이트가 추가/제거 되었을 때) `ImageDataSource`가 인덱스를 기반으로 데이터를 저장하고 있어서 변화된 인덱스 말고 기존 인덱스로 셀 이미지를 삽입하게 된다.

해결방안
- `ImageDataSource`가 인덱스가 아닌 UUID를 기반으로 이미지를 저장할 수 있도록 한다.