### PR TITLE
[feat] 산책 수락, 거절 화면 구현 

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -62,8 +62,8 @@
 		320047BB2CFD368100D08B6D /* PushNotificationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047BA2CFD367E00D08B6D /* PushNotificationRequest.swift */; };
 		320047BE2CFDE37300D08B6D /* WalkRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047BD2CFDE36C00D08B6D /* WalkRequestDTO.swift */; };
 		320047DE2CFE9E0400D08B6D /* Extension + UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */; };
-		9919104F2CFF552C008F86D6 /* OnBoardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */; };
 		3200480C2CFF0FB400D08B6D /* ProfileDropAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200480B2CFF0FA600D08B6D /* ProfileDropAnimation.swift */; };
+		9919104F2CFF552C008F86D6 /* OnBoardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */; };
 		9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */; };
 		993736422CFCACB100E3DD58 /* UpdateUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */; };
 		995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */; };
@@ -220,6 +220,10 @@
 		FDCD02D52CE9182200B627D8 /* SNMNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCD02D32CE9182200B627D8 /* SNMNetworkTests.swift */; };
 		FDCD02D72CE9182F00B627D8 /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCD02D62CE9182A00B627D8 /* AnyEncodableTests.swift */; };
 		FDCD02D92CE9183700B627D8 /* EndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCD02D82CE9183200B627D8 /* EndpointTests.swift */; };
+		FDDDB9362D00421F000D4528 /* ProcessedWalkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDDB9352D004214000D4528 /* ProcessedWalkViewController.swift */; };
+		FDDDB9382D004233000D4528 /* ProcessedWalkPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDDB9372D00422D000D4528 /* ProcessedWalkPresenter.swift */; };
+		FDDDB93A2D00423D000D4528 /* ProcessedWalkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDDB9392D004238000D4528 /* ProcessedWalkRouter.swift */; };
+		FDDDB93C2D004247000D4528 /* ProcessedWalkInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDDB93B2D004242000D4528 /* ProcessedWalkInteractor.swift */; };
 		FDE14A4E2CE8D144001F7A9D /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE14A4D2CE8D13E001F7A9D /* HTTPStatusCode.swift */; };
 		FDE14A502CE8D2FB001F7A9D /* URLRequest + append.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE14A4F2CE8D2E7001F7A9D /* URLRequest + append.swift */; };
 		FDE14A522CE8D338001F7A9D /* SNMRequestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE14A512CE8D331001F7A9D /* SNMRequestType.swift */; };
@@ -301,8 +305,8 @@
 		320047BA2CFD367E00D08B6D /* PushNotificationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRequest.swift; sourceTree = "<group>"; };
 		320047BD2CFDE36C00D08B6D /* WalkRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkRequestDTO.swift; sourceTree = "<group>"; };
 		320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIApplication.swift"; sourceTree = "<group>"; };
-		9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingPage.swift; sourceTree = "<group>"; };
 		3200480B2CFF0FA600D08B6D /* ProfileDropAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDropAnimation.swift; sourceTree = "<group>"; };
+		9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingPage.swift; sourceTree = "<group>"; };
 		9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUserInfoRemoteUseCase.swift; sourceTree = "<group>"; };
 		993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserInfoUseCase.swift; sourceTree = "<group>"; };
 		995D94252CE32EC1005A47BF /* Extension + Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + Keyboard.swift"; sourceTree = "<group>"; };
@@ -419,6 +423,10 @@
 		FDCD02D32CE9182200B627D8 /* SNMNetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMNetworkTests.swift; sourceTree = "<group>"; };
 		FDCD02D62CE9182A00B627D8 /* AnyEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
 		FDCD02D82CE9183200B627D8 /* EndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointTests.swift; sourceTree = "<group>"; };
+		FDDDB9352D004214000D4528 /* ProcessedWalkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessedWalkViewController.swift; sourceTree = "<group>"; };
+		FDDDB9372D00422D000D4528 /* ProcessedWalkPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessedWalkPresenter.swift; sourceTree = "<group>"; };
+		FDDDB9392D004238000D4528 /* ProcessedWalkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessedWalkRouter.swift; sourceTree = "<group>"; };
+		FDDDB93B2D004242000D4528 /* ProcessedWalkInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessedWalkInteractor.swift; sourceTree = "<group>"; };
 		FDE14A4D2CE8D13E001F7A9D /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
 		FDE14A4F2CE8D2E7001F7A9D /* URLRequest + append.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest + append.swift"; sourceTree = "<group>"; };
 		FDE14A512CE8D331001F7A9D /* SNMRequestType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMRequestType.swift; sourceTree = "<group>"; };
@@ -540,6 +548,7 @@
 		3200448B2CEC877500D08B6D /* View */ = {
 			isa = PBXGroup;
 			children = (
+				FDDDB9352D004214000D4528 /* ProcessedWalkViewController.swift */,
 				FD11526E2CFB33B0008955C4 /* RespondMapViewController.swift */,
 				3200448C2CEC877C00D08B6D /* RespondWalkViewController.swift */,
 			);
@@ -549,6 +558,7 @@
 		3200448E2CED778600D08B6D /* Interactor */ = {
 			isa = PBXGroup;
 			children = (
+				FDDDB93B2D004242000D4528 /* ProcessedWalkInteractor.swift */,
 				320044932CED80B000D08B6D /* RespondWalkInteractor.swift */,
 			);
 			path = Interactor;
@@ -557,6 +567,7 @@
 		3200448F2CED77AC00D08B6D /* Presenter */ = {
 			isa = PBXGroup;
 			children = (
+				FDDDB9372D00422D000D4528 /* ProcessedWalkPresenter.swift */,
 				FD1152702CFB386B008955C4 /* RespondMapPresenter.swift */,
 				320044912CED78C100D08B6D /* RespondWalkPresenter.swift */,
 			);
@@ -566,6 +577,7 @@
 		320044902CED77B200D08B6D /* Router */ = {
 			isa = PBXGroup;
 			children = (
+				FDDDB9392D004238000D4528 /* ProcessedWalkRouter.swift */,
 				FD1152722CFB3A83008955C4 /* RespondMapRouter.swift */,
 				320044952CED80D100D08B6D /* RespondWalkRouter.swift */,
 			);
@@ -1917,6 +1929,7 @@
 				FDEAEA7C2CE314A7005890FA /* BaseViewController.swift in Sources */,
 				FDE768A12CF7873600B5DE88 /* RequestNotificationAuthUseCase.swift in Sources */,
 				FD1152712CFB3872008955C4 /* RespondMapPresenter.swift in Sources */,
+				FDDDB93A2D00423D000D4528 /* ProcessedWalkRouter.swift in Sources */,
 				320047852CF80B2600D08B6D /* MateList.swift in Sources */,
 				A21435F72CE20D2500564A4D /* TabBarController.swift in Sources */,
 				320043762CDCA18E00D08B6D /* (null) in Sources */,
@@ -1962,6 +1975,7 @@
 				FD69B1B32CE3BC76009D71DC /* KeychainManager.swift in Sources */,
 				FD1152732CFB3A8A008955C4 /* RespondMapRouter.swift in Sources */,
 				320043782CDCA49100D08B6D /* (null) in Sources */,
+				FDDDB9382D004233000D4528 /* ProcessedWalkPresenter.swift in Sources */,
 				A24082612CEB244C009109A0 /* SupabaseConfig.swift in Sources */,
 				FD06342A2CE596D0003C9D6B /* NetworkProvider.swift in Sources */,
 				A2BD49F22CF72A9500AC72A7 /* DogProfileDTO.swift in Sources */,
@@ -2032,6 +2046,7 @@
 				FDE768922CF7828700B5DE88 /* AnyJSONSerializable.swift in Sources */,
 				9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */,
 				FD331A602CF339B000F39426 /* SupabaseStorageRequest.swift in Sources */,
+				FDDDB93C2D004247000D4528 /* ProcessedWalkInteractor.swift in Sources */,
 				320044892CEC862D00D08B6D /* LocationSelectionView.swift in Sources */,
 				3200480C2CFF0FB400D08B6D /* ProfileDropAnimation.swift in Sources */,
 				FD331A4D2CF235A100F39426 /* SNMLineTabBar.swift in Sources */,
@@ -2043,6 +2058,7 @@
 				FDE14A4E2CE8D144001F7A9D /* HTTPStatusCode.swift in Sources */,
 				3200441E2CE48D3500D08B6D /* MPCManager.swift in Sources */,
 				FDE768902CF7827D00B5DE88 /* AnyDecodable.swift in Sources */,
+				FDDDB9362D00421F000D4528 /* ProcessedWalkViewController.swift in Sources */,
 				FD0634312CE62578003C9D6B /* AnyEncodable.swift in Sources */,
 				FDE768962CF7831000B5DE88 /* RegisterDeviceTokenUseCase.swift in Sources */,
 				A23A3B732CF4683F00A58705 /* Mate.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/App/AppDelegate.swift
+++ b/SniffMeet/SniffMeet/Source/App/AppDelegate.swift
@@ -64,7 +64,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         case .walkRequest:
             sceneDelegate.appRouter?.presentRespondWalkView(walkNoti: walkNoti)
         case .walkAccepted, .walkDeclined:
-            sceneDelegate.appRouter?.presentRespondWalkView(walkNoti: walkNoti)
+            sceneDelegate.appRouter?.presentProcessedWalkView(walkNoti: walkNoti)
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/App/AppRouter.swift
+++ b/SniffMeet/SniffMeet/Source/App/AppRouter.swift
@@ -28,7 +28,6 @@ final class AppRouter: NSObject, Routable {
     private func displayTabBar() {
         let submodules = (
             home: UINavigationController(rootViewController: HomeModuleBuilder.build()),
-//            walk: UINavigationController(rootViewController: WalkLogPageViewController()),
             mate: UINavigationController(rootViewController: MateListRouter.createMateListModule())
         )
         window?.rootViewController = TabBarModuleBuilder.build(usingSubmodules: submodules)
@@ -49,12 +48,12 @@ final class AppRouter: NSObject, Routable {
     func moveToHomeScreen() {
         let submodules = (
             home: UINavigationController(rootViewController:  HomeModuleBuilder.build()),
-//            walk: UINavigationController(rootViewController: WalkLogPageViewController()),
+            //            walk: UINavigationController(rootViewController: WalkLogPageViewController()),
             mate: UINavigationController(rootViewController: MateListRouter.createMateListModule())
         )
         window?.rootViewController = TabBarModuleBuilder.build(usingSubmodules: submodules)
     }
-    /// 뷰에 진입한 후 산책 응답 화면을 present 합니다.
+    /// 뷰에 진입한 후 산책 요청 화면을 present 합니다.
     func initializeViewAndPresentRespondView(walkNoti: WalkNoti) {
         Task { @MainActor in
             do {
@@ -66,11 +65,27 @@ final class AppRouter: NSObject, Routable {
             }
         }
     }
+    /// 뷰에 진입한 후 산책 응답 화면을 present 합니다.
+    func initializeViewAndPresentProcessedWalkView(walkNoti: WalkNoti) {
+        Task { @MainActor in
+            do {
+                try await SupabaseAuthManager.shared.restoreSession()
+                displayTabBar()
+                presentProcessedWalkView(walkNoti: walkNoti)
+            } catch {
+                displayProfileSetupView()
+            }
+        }
+    }
     func presentRespondWalkView(walkNoti: WalkNoti) {
         let respondWalkViewController = RespondWalkRouter.createRespondtWalkModule(
             walkNoti: walkNoti
         )
         presentCardViewController(viewController: respondWalkViewController)
+    }
+    func presentProcessedWalkView(walkNoti: WalkNoti) {
+        let processedWalkViewController = ProcessedWalkRouter.createProcessedWalkView(noti: walkNoti)
+        presentCardViewController(viewController: processedWalkViewController)
     }
     private func presentCardViewController(viewController: UIViewController) {
         viewController.modalPresentationStyle = .custom

--- a/SniffMeet/SniffMeet/Source/App/SessionViewController.swift
+++ b/SniffMeet/SniffMeet/Source/App/SessionViewController.swift
@@ -59,10 +59,15 @@ final class SessionViewController: BaseViewController {
         ])
     }
     private func routeView() {
-        if let walkNoti {
-            appRouter?.initializeViewAndPresentRespondView(walkNoti: walkNoti)
-        } else {
+        guard let walkNoti else {
             appRouter?.displayInitialScreen()
+            return
+        }
+        switch walkNoti.category {
+        case .walkRequest:
+            appRouter?.initializeViewAndPresentRespondView(walkNoti: walkNoti)
+        case .walkAccepted, .walkDeclined:
+            appRouter?.initializeViewAndPresentProcessedWalkView(walkNoti: walkNoti)
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/Home/Alarm/Router/NotificationListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Home/Alarm/Router/NotificationListRouter.swift
@@ -34,7 +34,7 @@ final class NotificationListRouter: NSObject, NotificationListRoutable {
         case .walkRequest:
             RespondWalkRouter.createRespondtWalkModule(walkNoti: walkNoti)
         case .walkAccepted, .walkDeclined:
-            RespondWalkRouter.createRespondtWalkModule(walkNoti: walkNoti)
+            ProcessedWalkRouter.createProcessedWalkView(noti: walkNoti)
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Interactor/ProcessedWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Interactor/ProcessedWalkInteractor.swift
@@ -1,0 +1,68 @@
+//
+//  ProcessedWalkInteractor.swift
+//  SniffMeet
+//
+//  Created by sole on 12/4/24.
+//
+
+import Foundation
+
+protocol ProcessedWalkInteractable: AnyObject {
+    var presenter: (any ProcessedWalkInteractorOutput)? { get set }
+    func fetchSenderInfo(userId: UUID)
+    func fetchProfileImage(urlString: String)
+    func convertLocationToText(latitude: Double, longtitude: Double)
+}
+
+final class ProcessedWalkInteractor: ProcessedWalkInteractable {
+    weak var presenter: (any ProcessedWalkInteractorOutput)?
+    private let convertLocationToTextUseCase: any ConvertLocationToTextUseCase
+    private let requestUserInfoUseCase: RequestMateInfoUseCase
+    private let requestProfileImageUseCase: RequestProfileImageUseCase
+
+    init(
+        presenter: (any ProcessedWalkInteractorOutput)? = nil,
+        convertLocationToTextUseCase: any ConvertLocationToTextUseCase,
+        requestUserInfoUseCase: any RequestMateInfoUseCase,
+        requestProfileImageUseCase: any RequestProfileImageUseCase
+    ) {
+        self.presenter = presenter
+        self.convertLocationToTextUseCase = convertLocationToTextUseCase
+        self.requestUserInfoUseCase = requestUserInfoUseCase
+        self.requestProfileImageUseCase = requestProfileImageUseCase
+    }
+
+    func fetchSenderInfo(userId: UUID) {
+        Task {
+            do {
+                guard let senderInfo = try await requestUserInfoUseCase.execute(
+                    mateId: userId
+                ) else {
+                    presenter?.didFailToFetchWalkRequest(
+                        error: SupabaseError.notFound
+                    )
+                    return
+                }
+                presenter?.didFetchUserInfo(senderInfo: senderInfo)
+                guard let profileImageURL = senderInfo.profileImageURL else { return }
+                fetchProfileImage(urlString: profileImageURL)
+            } catch {
+                presenter?.didFailToFetchWalkRequest(error: error)
+            }
+        }
+    }
+    func fetchProfileImage(urlString: String) {
+        Task { [weak self] in
+            let imageData = try await self?.requestProfileImageUseCase.execute(fileName: urlString)
+            self?.presenter?.didFetchProfileImage(with: imageData)
+        }
+    }
+    func convertLocationToText(latitude: Double, longtitude: Double) {
+        Task {
+            let locationText: String? = await convertLocationToTextUseCase.execute(
+                latitude: latitude, longtitude: longtitude
+            )
+            presenter?.didConvertLocationToText(with: locationText)
+        }
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Presenter/ProcessedWalkPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Presenter/ProcessedWalkPresenter.swift
@@ -1,0 +1,110 @@
+//
+//  ProcessedWalkPresenter.swift
+//  SniffMeet
+//
+//  Created by sole on 12/4/24.
+//
+
+import Combine
+import UIKit
+
+protocol ProcessedWalkPresentable: AnyObject {
+    var noti: WalkNoti { get }
+    var view: (any ProcessedWalkViewable)? { get set }
+    var output: (any ProcessedWalkPresenterOutput) { get }
+
+    func viewDidLoad()
+    func dismissView()
+    func didTapLocationViewButton()
+}
+
+protocol ProcessedWalkInteractorOutput: AnyObject {
+    func didConvertLocationToText(with: String?)
+    func didFetchProfileImage(with: Data?)
+    func didFetchUserInfo(senderInfo: UserInfoDTO)
+    func didFailToFetchWalkRequest(error: any Error)
+}
+
+final class ProcessedWalkPresenter: ProcessedWalkPresentable {
+    private(set) var noti: WalkNoti
+    weak var view: (any ProcessedWalkViewable)?
+    var interactor: (any ProcessedWalkInteractable)?
+    var router: (any ProcessedWalkRoutable)?
+    var output: (any ProcessedWalkPresenterOutput)
+
+    init(
+        noti: WalkNoti,
+        view: (any ProcessedWalkViewable)? = nil,
+        interactor: (any ProcessedWalkInteractable)? = nil,
+        router: (any ProcessedWalkRoutable)? = nil,
+        output: any ProcessedWalkPresenterOutput = DefaultProcessedWalkPresenterOutput(
+            locationLabel: CurrentValueSubject(nil),
+            profileImage: CurrentValueSubject(nil)
+        )
+    ) {
+        self.noti = noti
+        self.view = view
+        self.output = output
+    }
+
+    func viewDidLoad() {
+        interactor?.fetchSenderInfo(userId: noti.senderId)
+        interactor?.convertLocationToText(
+            latitude: noti.latitude,
+            longtitude: noti.longtitude
+        )
+    }
+    func dismissView() {
+        guard let view else { return }
+        router?.dismiss(view: view)
+    }
+    func didTapLocationViewButton() {
+        guard let view else { return }
+        let address: Address = Address(
+            longtitude: noti.longtitude,
+            latitude: noti.latitude
+        )
+        router?.showSelectedLocationMapView(view: view, address: address)
+    }
+}
+
+// MARK: - ProcessedWalkPresenter+ProcessedWalkInteractorOutput
+
+extension ProcessedWalkPresenter: ProcessedWalkInteractorOutput {
+    func didConvertLocationToText(with: String?) {
+        output.locationLabel.send(with)
+    }
+    func didFetchProfileImage(with: Data?) {
+        guard let imageData = with else { return }
+        output.profileImage.send(UIImage(data: imageData))
+    }
+    func didFetchUserInfo(senderInfo: UserInfoDTO) {
+        let walkRequest = WalkRequestDetail(
+            mate: senderInfo.toEntity(),
+            address: Address(
+                longtitude: noti.longtitude,
+                latitude: noti.latitude
+            ),
+            message: noti.message
+        )
+        let isAccepted = (noti.category == .walkAccepted)
+        Task { @MainActor [weak self] in
+            self?.view?.showRequestDetail(isAccepted: isAccepted, request: walkRequest)
+        }
+    }
+    func didFailToFetchWalkRequest(error: any Error) {
+        // TODO: have to fill 
+    }
+}
+
+// MARK: - ProcessedWalkPresenterOutput
+
+protocol ProcessedWalkPresenterOutput {
+    var locationLabel: CurrentValueSubject<String?, Never> { get }
+    var profileImage: CurrentValueSubject<UIImage?, Never> { get }
+}
+
+struct DefaultProcessedWalkPresenterOutput: ProcessedWalkPresenterOutput {
+    let locationLabel: CurrentValueSubject<String?, Never>
+    let profileImage: CurrentValueSubject<UIImage?, Never>
+}

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Presenter/ProcessedWalkPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Presenter/ProcessedWalkPresenter.swift
@@ -11,6 +11,8 @@ import UIKit
 protocol ProcessedWalkPresentable: AnyObject {
     var noti: WalkNoti { get }
     var view: (any ProcessedWalkViewable)? { get set }
+    var interactor: (any ProcessedWalkInteractable)? { get set }
+    var router: (any ProcessedWalkRoutable)? { get set }
     var output: (any ProcessedWalkPresenterOutput) { get }
 
     func viewDidLoad()

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/ProcessedWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/ProcessedWalkRouter.swift
@@ -42,7 +42,8 @@ extension ProcessedWalkModuleBuildable {
             requestProfileImageUseCase: RequestProfileImageUseCaseImpl(
                 remoteImageManager: SupabaseStorageManager(
                     networkProvider: SNMNetworkProvider()
-                )
+                ),
+                cacheManager: ImageNSCacheManager.shared
             )
         )
         let router = ProcessedWalkRouter()

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/ProcessedWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/Router/ProcessedWalkRouter.swift
@@ -1,0 +1,58 @@
+//
+//  ProcessedWalkRouter.swift
+//  SniffMeet
+//
+//  Created by sole on 12/4/24.
+//
+
+import UIKit
+
+protocol ProcessedWalkRoutable: Routable {
+    func dismiss(view: any ProcessedWalkViewable)
+    func showSelectedLocationMapView(view: any ProcessedWalkViewable, address: Address)
+}
+
+final class ProcessedWalkRouter: ProcessedWalkRoutable {
+    func dismiss(view: any ProcessedWalkViewable) {
+        guard let view = view as? UIViewController else { return }
+        dismiss(from: view, animated: true)
+    }
+    func showSelectedLocationMapView(view: any ProcessedWalkViewable, address: Address) {
+        guard let view = view as? UIViewController else { return }
+        let selectedLocationView = RespondMapRouter.createRespondMapView(address: address)
+        fullScreen(from: view, with: selectedLocationView, animated: true)
+    }
+}
+
+extension ProcessedWalkRouter: ProcessedWalkModuleBuildable {}
+
+// MARK: - ProcessedWalkModuleBuildable
+
+protocol ProcessedWalkModuleBuildable {
+    static func createProcessedWalkView(noti: WalkNoti) -> UIViewController
+}
+
+extension ProcessedWalkModuleBuildable {
+    static func createProcessedWalkView(noti: WalkNoti) -> UIViewController {
+        let view = ProcessedWalkViewController()
+        let presenter = ProcessedWalkPresenter(noti: noti)
+        let interactor = ProcessedWalkInteractor(
+            convertLocationToTextUseCase: ConvertLocationToTextUseCaseImpl(),
+            requestUserInfoUseCase: RequestMateInfoUsecaseImpl(),
+            requestProfileImageUseCase: RequestProfileImageUseCaseImpl(
+                remoteImageManager: SupabaseStorageManager(
+                    networkProvider: SNMNetworkProvider()
+                )
+            )
+        )
+        let router = ProcessedWalkRouter()
+
+        view.presenter = presenter
+        presenter.view = view
+        presenter.interactor = interactor
+        presenter.router = router
+        interactor.presenter = presenter
+
+        return view
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Walk/RespondWalk/View/ProcessedWalkViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Walk/RespondWalk/View/ProcessedWalkViewController.swift
@@ -1,0 +1,209 @@
+//
+//  ProcessedWalkViewController.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 11/19/24.
+//
+
+import Combine
+import UIKit
+
+protocol ProcessedWalkViewable: AnyObject {
+    var presenter: (any ProcessedWalkPresentable)? { get set }
+
+    func showRequestDetail(isAccepted: Bool, request: WalkRequestDetail)
+}
+
+final class ProcessedWalkViewController: BaseViewController, ProcessedWalkViewable {
+    var presenter: (any ProcessedWalkPresentable)?
+    private var cancellables: Set<AnyCancellable> = []
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
+    private var dismissButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "xmark"), for: .normal)
+        button.tintColor = SNMColor.mainNavy
+        return button
+    }()
+    private var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "title"
+        label.font = SNMFont.title3
+        label.textColor = SNMColor.mainNavy
+        label.textAlignment = .center
+        return label
+    }()
+    private var profileView: ProfileView = {
+        let view = ProfileView()
+        view.layer.cornerRadius = 15
+        view.clipsToBounds = true
+        return view
+    }()
+    private var locationView = LocationSelectionView()
+    private var messageLabel: PaddingLabel = {
+        let label = PaddingLabel()
+        label.backgroundColor = SNMColor.subGray1
+        label.textColor = SNMColor.subBlack1
+        label.font = SNMFont.body
+        label.layer.cornerRadius = 10
+        label.clipsToBounds = true
+        label.numberOfLines = 4
+        return label
+    }()
+    private var confirmButton = PrimaryButton(title: Context.confirmButtonTitle)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        presenter?.viewDidLoad()
+    }
+    override func configureAttributes() {
+        profileView.configure(
+            name: UserInfo.example.name,
+            keywords: UserInfo.example.keywords.map { $0.rawValue }
+        )
+        titleLabel.text = (presenter?.noti.category == .walkAccepted) ?
+        Context.acceptedRequestTitle : Context.declinedRequestTitle
+        messageLabel.text = Context.defaultMessageContent
+    }
+    override func configureHierachy() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+
+        [scrollView, contentView].forEach{
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        [titleLabel,
+        dismissButton,
+         profileView,
+         locationView,
+         messageLabel,
+         confirmButton].forEach
+        {
+            contentView.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+    }
+    override func configureConstraints() {
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            contentView.topAnchor.constraint(equalTo:
+                                                scrollView.contentLayoutGuide.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo:
+                                                    scrollView.contentLayoutGuide.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo:
+                                                    scrollView.contentLayoutGuide.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo:
+                                                    scrollView.contentLayoutGuide.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+            contentView.heightAnchor.constraint(equalToConstant:
+                                                    max(650, view.bounds.size.height * 0.8))
+        ])
+
+        NSLayoutConstraint.activate([
+            dismissButton.topAnchor.constraint(equalTo: contentView.topAnchor,
+                                               constant: LayoutConstant.regularVerticalPadding),
+            dismissButton.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: -LayoutConstant.smallHorizontalPadding),
+            dismissButton.heightAnchor.constraint(equalToConstant: LayoutConstant.iconSize),
+            dismissButton.widthAnchor.constraint(equalToConstant: LayoutConstant.iconSize),
+            titleLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor,
+                                            constant: LayoutConstant.xlargeVerticalPadding),
+            titleLabel.heightAnchor.constraint(equalToConstant: 30),
+            profileView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
+            profileView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            profileView.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.4),
+            profileView.widthAnchor.constraint(equalTo: profileView.heightAnchor),
+            locationView.topAnchor.constraint(
+                equalTo: profileView.bottomAnchor,
+                constant: LayoutConstant.mediumVerticalPadding),
+            locationView.heightAnchor.constraint(equalToConstant: 25),
+            messageLabel.topAnchor.constraint(
+                equalTo: locationView.bottomAnchor,
+                constant: LayoutConstant.regularVerticalPadding),
+            messageLabel.bottomAnchor.constraint(
+                equalTo: confirmButton.topAnchor,
+                constant: -LayoutConstant.regularVerticalPadding
+            ),
+            confirmButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor,
+                                                 constant: -LayoutConstant.xlargeVerticalPadding),
+            confirmButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
+
+        [locationView, messageLabel, confirmButton].forEach {
+            $0.leadingAnchor.constraint(
+                equalTo: contentView.leadingAnchor,
+                constant: LayoutConstant.smallHorizontalPadding).isActive = true
+            $0.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: -LayoutConstant.smallHorizontalPadding).isActive = true
+        }
+    }
+    override func bind() {
+        presenter?.output.locationLabel
+            .receive(on: RunLoop.main)
+            .sink { [weak self] locationLabel in
+                guard let locationLabel else { return }
+                self?.locationView.setAddress(address: locationLabel)
+            }
+            .store(in: &cancellables)
+
+        dismissButton.publisher(event: .touchUpInside)
+            .receive(on: RunLoop.main)
+            .sink {[weak self] _ in
+                guard let self else { return }
+                presenter?.dismissView()
+            }
+            .store(in: &cancellables)
+
+        confirmButton.publisher(event: .touchUpInside)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.presenter?.dismissView()
+            }
+            .store(in: &cancellables)
+
+        presenter?.output.profileImage
+            .receive(on: RunLoop.main)
+            .sink { [weak self] image in
+                self?.profileView.configureImage(with: image)
+            }
+            .store(in: &cancellables)
+
+        locationView.tapPublisher
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.presenter?.didTapLocationViewButton()
+            }
+            .store(in: &cancellables)
+    }
+}
+
+// MARK: - ProcessedWalkViewController+Context
+
+private extension ProcessedWalkViewController {
+    enum Context {
+        static let acceptedRequestTitle: String = "산책 요청이 수락됐어요!"
+        static let declinedRequestTitle: String = "산책 요청이 거절됐어요."
+        static let confirmButtonTitle: String = "확인"
+        static let defaultMessageContent: String = "HomeView에서 dogInfo의 변경을 알아야 하더라구요. Presenter에서 HomePresenterOutput 프로토콜을 채택하도록 설정해줬습니다."
+    }
+}
+
+// MARK: - ProcessedWalkViewController+Viewable method
+
+extension ProcessedWalkViewController {
+    func showRequestDetail(isAccepted: Bool, request: WalkRequestDetail) {
+        titleLabel.text = isAccepted ?
+        Context.acceptedRequestTitle : Context.declinedRequestTitle
+        messageLabel.text = request.message
+        profileView.configure(
+            name: request.mate.name,
+            keywords: request.mate.keywords.map { $0.rawValue }
+        )
+    }
+}


### PR DESCRIPTION
### 🔖  Issue Number

close #196 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
-  산책 수락, 요청 화면 

- 산책 수락, 요청 화면 화면 전환 로직 연결 
AppRouter, NotificationList 에 화면들을 연결했습니다. 

- NotificationList에서 Cell을 탭했을 때 화면전환 

<img src="https://github.com/user-attachments/assets/98d87198-01af-4e26-a5e7-0b4261569cf8" height=300>

- Push Notification을 탭했을 때 화면전환 

<img src="https://github.com/user-attachments/assets/797bdfd3-1533-4ccd-bdd6-b37e685a292e" height=300>

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 지성님이 구현해주신 `RespondWalkView` 부분을 많이 참고했습니다. 단순 정보 전달용 뷰라고 생각했기에 타이머, 산책 요청 보내기 등의 기능은 제거했습니다. 