### PR TITLE
[fix] profiledrop 연결 상태에 따른 button / alert 상태 변경

### DIFF
--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -172,7 +172,7 @@ extension MPCManager: MCSessionDelegate {
             }
         default:
             Task { @MainActor in
-                self.paired = false
+                self.paired = true
             }
         }
     }

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Presenter/MateListPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Presenter/MateListPresenter.swift
@@ -17,7 +17,8 @@ protocol MateListPresentable: AnyObject {
     func viewWillAppear()
     func didTableViewCellLoad(index: Int, imageName: String?)
     func didTabAccessoryButton(mate: Mate)
-    func changeIsPaired(with isPaired: Bool)
+    func showAlertConnected()
+    func showAlertDisconnected()
     func profileData(_ data: DogProfileDTO)
 }
 
@@ -61,21 +62,22 @@ final class MateListPresenter: MateListPresentable {
         router?.presentWalkRequestView(mateListView: view, mate: mate)
     }
 
-    func changeIsPaired(with isPaired: Bool) {
+    func showAlertConnected() {
         guard let view else { return }
-        if isPaired {
-            router?.showAlert(
-                mateListView: view,
-                title: "Connected",
-                message: "성공적으로 연결되었습니다.\n핸드폰끼리 카메라 방향으로 가까이하여 프로필을 교환해보세요."
-            )
-        } else {
-            router?.showAlert(
-                mateListView: view,
-                title: "Disconnected",
-                message: "메이트 찾기 실패하였습니다.\n 와이파이와 블루투스가 켜져있는 상태인지 확인해주세요."
-            )
-        }
+        router?.showAlert(
+            mateListView: view,
+            title: "Connected",
+            message: "성공적으로 연결되었습니다.\n핸드폰끼리 카메라 방향으로 가까이하여 프로필을 교환해보세요."
+        )
+    }
+
+    func showAlertDisconnected() {
+        guard let view else { return }
+        router?.showAlert(
+            mateListView: view,
+            title: "Disconnected",
+            message: "메이트 찾기 실패하였습니다.\n 와이파이와 블루투스가 켜져있는 상태인지 확인해주세요."
+        )
     }
 
     func profileData(_ data: DogProfileDTO) {

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
@@ -44,11 +44,9 @@ final class MateListRouter: MateListRoutable {
     func showMateRequestView(mateListView: any MateListViewable, data: DogProfileDTO) {
         guard let mateListView = mateListView as? UIViewController else { return }
         let requestMateViewController = RequestMateRouter.createRequestMateModule(profile: data)
+        let transitionDelegate = ProfileDropTransitionDelegate()
         requestMateViewController.modalPresentationStyle = .fullScreen
-
-        if let mateListView = mateListView as?  UIViewControllerTransitioningDelegate {
-            requestMateViewController.transitioningDelegate = mateListView
-        }
+        requestMateViewController.transitioningDelegate = transitionDelegate
         present(from: mateListView, with: requestMateViewController, animated: true)
     }
 }

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/View/AddMateButton.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/View/AddMateButton.swift
@@ -21,19 +21,19 @@ final class AddMateButton: UIButton {
             switch buttonState {
             case .normal:
                 configuration?.background.backgroundColor = SNMColor.mainNavy
-                configuration?.title = "친구를 찾아보세요"
+                configuration?.title = "새 메이트를 연결하세요"
                 configuration?.image = UIImage(systemName: "plus.magnifyingglass")
             case .connecting:
-                configuration?.background.backgroundColor = UIColor.systemGray
+                configuration?.background.backgroundColor = SNMColor.disabledGray
                 configuration?.title = "연결 중..."
                 configuration?.image = UIImage(systemName: "wifi")
             case .success:
-                configuration?.background.backgroundColor = UIColor.systemGreen
-                configuration?.title = "성공"
+                configuration?.background.backgroundColor = SNMColor.mainBrown
+                configuration?.title = "연결 성공, 프로필드랍 시도하세요"
                 configuration?.image = UIImage(systemName: "checkmark.circle")
             case .failure:
-                configuration?.background.backgroundColor = UIColor.systemGreen
-                configuration?.title = "실패"
+                configuration?.background.backgroundColor = SNMColor.disabledGray
+                configuration?.title = "연결 실패"
                 configuration?.image = UIImage(systemName: "x.circle")
             }
         }

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
@@ -17,7 +17,7 @@ final class MateListViewController: BaseViewController, MateListViewable {
     var imageDataSource: [Int: Data] = [:]
     private var cancellables: Set<AnyCancellable> = []
     private let tableView: UITableView = UITableView()
-    private let addMateButton = AddMateButton(title: "친구를 만들어봐요")
+    private let addMateButton = AddMateButton(title: "새 메이트를 연결하세요")
     private var mpcManager: MPCManager?
     private var niManager: NIManager?
     private var count: Int = 0

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
@@ -105,7 +105,7 @@ final class MateListViewController: BaseViewController, MateListViewable {
                         self?.addMateButton.buttonState = .failure
                     }
                     self?.presenter?.changeIsPaired(with: isPaired)
-                    self?.addMateButton.buttonState = .normal
+                    self?.addMateButton.buttonState = .connecting
                 }
                 self?.count += 1
             }
@@ -119,10 +119,19 @@ final class MateListViewController: BaseViewController, MateListViewable {
             }
             .store(in: &cancellables)
 
+        niManager?.$niPaired
+            .receive(on: RunLoop.main)
+            .sink { [weak self] isPaired in
+                if !isPaired {
+                    self?.addMateButton.buttonState = .failure
+                }
+                self?.addMateButton.buttonState = .success
+            }
+            .store(in: &cancellables)
+
         niManager?.isViewTransitioning
             .receive(on: RunLoop.main)
             .sink { [weak self] bool in
-                self?.addMateButton.buttonState = .success
                 guard let profile = self?.dogProfile else {
                     SNMLogger.error("No exist profile")
                     return

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/View/MateListViewController.swift
@@ -103,8 +103,8 @@ final class MateListViewController: BaseViewController, MateListViewable {
                 if 1...3 ~= self?.count ?? 0 {
                     if !isPaired {
                         self?.addMateButton.buttonState = .failure
+                        self?.presenter?.showAlertDisconnected()
                     }
-                    self?.presenter?.changeIsPaired(with: isPaired)
                     self?.addMateButton.buttonState = .connecting
                 }
                 self?.count += 1
@@ -122,10 +122,12 @@ final class MateListViewController: BaseViewController, MateListViewable {
         niManager?.$niPaired
             .receive(on: RunLoop.main)
             .sink { [weak self] isPaired in
-                if !isPaired {
+                if isPaired {
+                    self?.presenter?.showAlertConnected()
+                    self?.addMateButton.buttonState = .success
+                } else {
                     self?.addMateButton.buttonState = .failure
                 }
-                self?.addMateButton.buttonState = .success
             }
             .store(in: &cancellables)
 


### PR DESCRIPTION
### 🔖  Issue Number

close #207

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] ProfileDrop 상태에 따른 버튼 상태 변경
- [x] ProfileDrop 상태에 따른 alert 상태 변경
- [x] ProfileDrop 시점 애니메이션 적용

https://github.com/user-attachments/assets/2b0fbe68-1988-4bc5-9d15-9dcc6f90b2a0

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1
기존 버튼 상태 변화가 MPC 연결 상태에만 맞춰 변경되어 NI 상태도 포함해 변경하도록 수정하였습니다.
수정하면서 버튼 텍스트도 살짝 변경하였습니다. 별로면 말씀해주세요!

- 특이 사항 2
테스트 도중 문제상황 2개 발견했습니다.
1. 메이트 관계에 있는 a,b 기기에서 a기기는 로그인을 새로해서 계정이 바뀌었고, b기기는 supabase에서 메이트 내역을 삭제한 이후에 다시 메이트 맺기를 요청하고 수락하면 b기기에 a의 옛 계정과 현재 계정 두개가 목록에 추가됩니다.

2. profiledrop 애니메이션 효과가 안나타났습니다.
확인해보니 진원님이 뷰 수정하시고 지성님이 애니메이션 적용하시고 하는 과정에서 PR 병합 시점에 누락된 것 같았습니다.
찾아서 추가했고 이제 애니메이션까지 동작 됩니다~ 왕귀왕귀



### 👻 레퍼런스

