### PR TITLE
[fix] 앱이 Non-running(Terminated) 상태일 때 Push Noti를 누르면 카드 뷰가 2번 present되는 현상 해결

### DIFF
--- a/SniffMeet/SniffMeet/Source/App/SessionViewController.swift
+++ b/SniffMeet/SniffMeet/Source/App/SessionViewController.swift
@@ -59,15 +59,13 @@ final class SessionViewController: BaseViewController {
         ])
     }
     private func routeView() {
-        guard let walkNoti else {
-            appRouter?.displayInitialScreen()
-            return
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.markFirstLaunchHandled()
         }
-        switch walkNoti.category {
-        case .walkRequest:
+        if let walkNoti {
             appRouter?.initializeViewAndPresentRespondView(walkNoti: walkNoti)
-        case .walkAccepted, .walkDeclined:
-            appRouter?.initializeViewAndPresentProcessedWalkView(walkNoti: walkNoti)
+        } else {
+            appRouter?.displayInitialScreen()
         }
     }
 }
@@ -78,3 +76,4 @@ extension SessionViewController {
         static let logoSmallTitleVerticalPadding: CGFloat = 19
     }
 }
+


### PR DESCRIPTION
### 🔖  Issue Number

close #213 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.

- [x]  foreground, background, non-running 상태에서 push noti가 발생할 때 화면전환 정상적으로 동작하게 하기   

## 구현 내용 설명 
### Foreground, Background과 Non-running 상태에서 다른 화면전환 플로우 
Foreground, Background 상태일 때와 Non-running 상태일 때 Push Noti를 선택하면 다른 플로우로 화면전환이 이루어집니다. 

1. Foreground, Background 상태 
   <img width="500" alt="스크린샷 2024-12-05 오후 2 40 28" src="https://github.com/user-attachments/assets/6bfc60f9-c971-45cf-972c-661e7fd710fb">

    Foreground, Background 상태는 AppDelegate에서 noti가 발생했을 때 별도의 선행되어야 하는 작업이 없습니다. 
    따라서 화면전환을 수행하는 AppRouter 메서드를 실행하여 화면전환을 합니다. 


2. Non-running 상태 
    <img width="800" alt="스크린샷 2024-12-05 오후 2 40 23" src="https://github.com/user-attachments/assets/6fe8e821-1920-4876-813b-8a77abb85d32">

    하지만 Non-running 상태는 다릅니다. 세션 복원과 초기 화면을 결정하는 작업이 선행되어야 합니다. 
    따라서 선행되는 작업을 수행하고 있는 SessionViewController에서 해당 작업이 끝나고 화면전환을 하는 AppRouter 메서드가 실행되어야 합니다. 

### AppDelegate에서 Noti를 받았을 때 실행되는 메서드 
아래 메서드에서 noti가 발생했을 때 실행됩니다. 
보이는 것처럼 async 메서드입니다.  foreground, background에서도 noti를 받아야 하니 async하게 동작해야 때문입니다. 

```swift
// AppDelegate.swift
func userNotificationCenter(
        _ center: UNUserNotificationCenter,
        didReceive response: UNNotificationResponse
    ) async
```
처음에는 앱의 상태(active, inactive, background, )에 따라 다르게 동작할 수 있도록 설정했습니다. 하지만 비동기 함수이므로 바로 실행되지 않습니다. 제가 테스트했을 때는 해당 함수가 실행될 때 앱이 active된 상태가 된걸 확인했습니다. 
이 때문에 상태에 따라 다르게 동작하는 로직이 제대로 실행되지 않았습니다. 

### 해결 방안
Non-running일 때 Foreground, Background와 다른 로직으로 실행하기 위해서 앱의 첫 실행 여부를 판단하는 변수를 추가했습니다. 
첫 실행이라면 아래 메서드에서 실행하지 않고 sessionViewController에서 실행할 수 있도록 했습니다. 
이렇게 하니 첫 실행인 경우 아래에서 화면전환이 이루어지지 않으니 present가 1번만 이루어집니다.
```swift
// AppDelegate.swift
    private var isFirstLaunch: Bool = true

 func userNotificationCenter(
        _ center: UNUserNotificationCenter,
        didReceive response: UNNotificationResponse
    ) async {
            guard let sceneDelegate = UIApplication.shared.connectedScenes
                .first?.delegate as? SceneDelegate else {
                return
            }
            
            if isFirstLaunch {
                markFirstLaunchHandled()
                return
            }
           ...

    }
```

동작 화면
- non-running, foreground, background 순으로 실행한 영상입니다. 
https://github.com/user-attachments/assets/947022d5-6b56-4562-ab5b-a97c865c8f2c

### 👻 레퍼런스
- 참고한 자료
[managing-your-app-s-life-cycle](https://developer.apple.com/documentation/uikit/managing-your-app-s-life-cycle)




