### PR TITLE
[feat] Disk Cache 적용

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -63,10 +63,10 @@
 		320047BE2CFDE37300D08B6D /* WalkRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047BD2CFDE36C00D08B6D /* WalkRequestDTO.swift */; };
 		320047DE2CFE9E0400D08B6D /* Extension + UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */; };
 		3200480C2CFF0FB400D08B6D /* ProfileDropAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200480B2CFF0FA600D08B6D /* ProfileDropAnimation.swift */; };
+		320522BE2D0181A800F1677C /* ImageCacheable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320522BD2D0181A700F1677C /* ImageCacheable.swift */; };
 		32A7563C2D00398100965F0A /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A7563B2D00397D00965F0A /* CacheManager.swift */; };
 		32A7563D2D00398100965F0A /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A7563B2D00397D00965F0A /* CacheManager.swift */; };
 		32A7563E2D00398100965F0A /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A7563B2D00397D00965F0A /* CacheManager.swift */; };
-		9919104F2CFF552C008F86D6 /* OnBoardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */; };
 		9919104F2CFF552C008F86D6 /* OnBoardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */; };
 		9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */; };
 		993736422CFCACB100E3DD58 /* UpdateUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */; };
@@ -310,6 +310,7 @@
 		320047BD2CFDE36C00D08B6D /* WalkRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkRequestDTO.swift; sourceTree = "<group>"; };
 		320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIApplication.swift"; sourceTree = "<group>"; };
 		3200480B2CFF0FA600D08B6D /* ProfileDropAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDropAnimation.swift; sourceTree = "<group>"; };
+		320522BD2D0181A700F1677C /* ImageCacheable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheable.swift; sourceTree = "<group>"; };
 		32A7563B2D00397D00965F0A /* CacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheManager.swift; sourceTree = "<group>"; };
 		9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingPage.swift; sourceTree = "<group>"; };
 		9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUserInfoRemoteUseCase.swift; sourceTree = "<group>"; };
@@ -529,6 +530,7 @@
 		320044792CEC490600D08B6D /* Entity */ = {
 			isa = PBXGroup;
 			children = (
+				320522BD2D0181A700F1677C /* ImageCacheable.swift */,
 				9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */,
 				FD331A512CF23BCE00F39426 /* WalkLog.swift */,
 				320044972CED81EF00D08B6D /* WalkNoti.swift */,
@@ -2013,6 +2015,7 @@
 				FD06342C2CE5984D003C9D6B /* SNMNetworkResponse.swift in Sources */,
 				3200445E2CE5CA1B00D08B6D /* SaveUserInfoUseCase.swift in Sources */,
 				995D94AA2CECF8DD005A47BF /* RequestMateInteractor.swift in Sources */,
+				320522BE2D0181A800F1677C /* ImageCacheable.swift in Sources */,
 				A25BE45A2CEC2BA300886763 /* SessionManager.swift in Sources */,
 				A24082672CEB2539009109A0 /* SupabaseSessionResponse.swift in Sources */,
 				FD51341B2CEB7AE8002E76F3 /* HomePresenter.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Entity/ImageCacheable.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/ImageCacheable.swift
@@ -1,0 +1,17 @@
+//
+//  Untitled.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 12/5/24.
+//
+import Foundation
+
+final class CacheableImage: Codable {
+    let lastModified: String
+    let imageData: Data
+
+    init(lastModified: String, imageData: Data) {
+        self.lastModified = lastModified
+        self.imageData = imageData
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -80,7 +80,6 @@ extension ImageNSCacheManager: ImageCacheable {
             return image
         }
         if let image = imageFromDiskCache(urlString: urlString) { // 디스크 캐시 hit
-            saveMemoryCache(urlString: urlString, cacheableImage: image)
             SNMLogger.info("disk cache hit")
             return image
         }

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -5,41 +5,86 @@
 //  Created by 윤지성 on 12/4/24.
 //
 
-import UIKit
-
-final class CacheableImage {
-    let lastModified: String
-    let imageData: Data
-
-    init(lastModified: String, imageData: Data) {
-        self.lastModified = lastModified
-        self.imageData = imageData
-    }
-}
+import Foundation
 
 protocol ImageCacheable {
-    func saveMemoryCache(urlString: String, lastModified: String?, imageData: Data?)
+    func save(urlString: String, lastModified: String?, imageData: Data?)
     func image(urlString: String) -> CacheableImage?
 }
 
-final class ImageNSCacheManager: ImageCacheable {
+final class ImageNSCacheManager {
     static let shared = ImageNSCacheManager()
-    private let cache: NSCache<NSString, CacheableImage>
     
-    private init(cache: NSCache<NSString, CacheableImage> = NSCache<NSString, CacheableImage>()) {
+    private let cache: NSCache<NSString, CacheableImage>
+    private let fileManager: FileManageable
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    
+    private var cacheDirectoryPath: URL {
+        let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        let diskCacheURL = cachesURL.appendingPathComponent("DownloadedCache")
+        return diskCacheURL
+    }
+
+    private init(
+        cache: NSCache<NSString, CacheableImage> = NSCache<NSString, CacheableImage>(),
+        fileManager: FileManageable = SNMFileManager())
+    {
         self.cache = cache
+        self.fileManager = fileManager
         cache.totalCostLimit = 5 * 1024 * 1024 // 5MB
     }
-    func saveMemoryCache(urlString: String, lastModified: String?, imageData: Data?) {
-        guard let lastModified,
-              let imageData else { return }
-        let cacheableImage = CacheableImage(lastModified: lastModified, imageData: imageData)
-        SNMLogger.info("miss")
+    
+    func saveMemoryCache(urlString: String, cacheableImage: CacheableImage) {
         cache.setObject(cacheableImage, forKey: urlString as NSString)
     }
     
-    func image(urlString: String) -> CacheableImage? {
-        SNMLogger.info("hit")
+    func saveDiskCache(urlString: String, cacheableImage: CacheableImage) {
+        do {
+            let data = try encoder.encode(cacheableImage)
+            try fileManager.set(data: data, forKey: urlString)
+        } catch {
+            SNMLogger.error("CacheManager-saveDiskCache: \(error.localizedDescription) ")
+        }
+    }
+    
+    func imageFromMemoryCache(urlString: String) -> CacheableImage? {
         return cache.object(forKey: urlString as NSString)
+    }
+    
+    func imageFromDiskCache(urlString: String) -> CacheableImage? {
+        do {
+            let data = try fileManager.fetch(forKey: urlString)
+            guard let data else { return nil }
+            return try? decoder.decode(CacheableImage.self, from: data)
+        } catch {
+            SNMLogger.error("CacheManager-imageFromDiskCache: \(error.localizedDescription) ")
+        }
+        return nil
+    }
+}
+
+extension ImageNSCacheManager: ImageCacheable {
+    func save(urlString: String, lastModified: String?, imageData: Data?) {
+        guard let lastModified,
+              let imageData else { return }
+        let cacheableImage = CacheableImage(lastModified: lastModified, imageData: imageData)
+        
+        saveMemoryCache(urlString: urlString, cacheableImage: cacheableImage)
+        saveDiskCache(urlString: urlString, cacheableImage: cacheableImage)
+    }
+    
+    func image(urlString: String) -> CacheableImage? {
+        if let image = imageFromMemoryCache(urlString: urlString) { // 메모리 캐시 hit
+            SNMLogger.info("memory cache hit")
+            return image
+        }
+        if let image = imageFromDiskCache(urlString: urlString) { // 디스크 캐시 hit
+            saveMemoryCache(urlString: urlString, cacheableImage: image)
+            SNMLogger.info("disk cache hit")
+            return image
+        }
+        // 모두 miss
+        return nil
     }
 }

--- a/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
+++ b/SniffMeet/SniffMeet/Source/Persistence/CacheManager.swift
@@ -71,6 +71,7 @@ extension ImageNSCacheManager: ImageCacheable {
         let cacheableImage = CacheableImage(lastModified: lastModified, imageData: imageData)
         
         saveMemoryCache(urlString: urlString, cacheableImage: cacheableImage)
+        if onlyMemory { return }
         saveDiskCache(urlString: urlString, cacheableImage: cacheableImage)
     }
     
@@ -81,6 +82,7 @@ extension ImageNSCacheManager: ImageCacheable {
         }
         if let image = imageFromDiskCache(urlString: urlString) { // 디스크 캐시 hit
             SNMLogger.info("disk cache hit")
+            saveMemoryCache(urlString: urlString, cacheableImage: image)
             return image
         }
         // 모두 miss

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/LoadUserInfoUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/LoadUserInfoUseCase.swift
@@ -21,7 +21,7 @@ struct LoadUserInfoUseCaseImpl: LoadUserInfoUseCase {
     func execute() throws -> UserInfo {
         var userInfo = try dataLoadable.loadData(forKey: Environment.UserDefaultsKey.dogInfo,
                                                  type: UserInfo.self)
-        userInfo.profileImage = try imageManageable.get(forKey: Environment.FileManagerKey.profileImage)
+        userInfo.profileImage = try imageManageable.image(forKey: Environment.FileManagerKey.profileImage)
         return userInfo
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
@@ -32,6 +32,9 @@ struct RequestProfileImageUseCaseImpl: RequestProfileImageUseCase {
                 )
                 if !remoteImage.isModified { // 변경되지 않음
                     SNMLogger.log("not modified")
+                    cacheManager.save(urlString: fileName,
+                                                 lastModified: cacheableImage.lastModified,
+                                                 imageData: cacheableImage.imageData)
                     return cacheableImage.imageData
                 } else {
                     cacheManager.save(urlString: fileName,

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
@@ -34,7 +34,7 @@ struct RequestProfileImageUseCaseImpl: RequestProfileImageUseCase {
                     SNMLogger.log("not modified")
                     return cacheableImage.imageData
                 } else {
-                    cacheManager.saveMemoryCache(urlString: fileName,
+                    cacheManager.save(urlString: fileName,
                                                  lastModified: remoteImage.lastModified,
                                                  imageData: remoteImage.imageData)
                     return remoteImage.imageData!
@@ -49,7 +49,7 @@ struct RequestProfileImageUseCaseImpl: RequestProfileImageUseCase {
                     fileName: fileName,
                     lastModified: ""
                 )
-                cacheManager.saveMemoryCache(urlString: fileName,
+                cacheManager.save(urlString: fileName,
                                              lastModified: remoteImage.lastModified,
                                              imageData: remoteImage.imageData)
                 return remoteImage.imageData

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestProfileImageUseCase.swift
@@ -32,9 +32,6 @@ struct RequestProfileImageUseCaseImpl: RequestProfileImageUseCase {
                 )
                 if !remoteImage.isModified { // 변경되지 않음
                     SNMLogger.log("not modified")
-                    cacheManager.save(urlString: fileName,
-                                                 lastModified: cacheableImage.lastModified,
-                                                 imageData: cacheableImage.imageData)
                     return cacheableImage.imageData
                 } else {
                     cacheManager.save(urlString: fileName,

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveUserInfoUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveUserInfoUseCase.swift
@@ -18,11 +18,13 @@ struct SaveUserInfoUseCaseImpl: SaveUserInfoUseCase {
         try localDataManager.storeData(data: dog, key: Environment.UserDefaultsKey.dogInfo)
         guard let imageData = dog.profileImage else { return }
         do {
-            try imageManager.set(imageData: imageData, forKey: Environment.FileManagerKey.profileImage)
+            try imageManager.setImage(imageData: imageData,
+                                      forKey: Environment.FileManagerKey.profileImage)
         } catch {
             SNMLogger.error("프로필 이미지 저장 실패: \(error.localizedDescription)")
         }
         
-        try localDataManager.storeData(data: [UUID(uuidString: "23f52fdb-5292-4afb-a8a4-6adb467b39ce")] , key: Environment.UserDefaultsKey.mateList)
+        try localDataManager.storeData(data: [UUID(uuidString: "23f52fdb-5292-4afb-a8a4-6adb467b39ce")],
+                                       key: Environment.UserDefaultsKey.mateList)
     }
 }


### PR DESCRIPTION
### 🔖  Issue Number

close #195

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  disk Cache 적용 

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 특이 사항 1
경우를 5가지로 나눌 수 있습니다. ㅎㅎ 
1. imageCache에 존재하는 경우(diskCache에 당연히 존재)지만 서버에서 이미지가 변경된 경우 (status code = 200)
2. imageCache에 존재하는 경우(diskCache에 당연히 존재)지만 서버에서 이미지가 변경되지 않은 경우 (status code = 304)
3. diskCache에 존재한는 경우 서버에서 이미지가 변경된 경우 (status code = 200)
4. diskCache에 존재한는 경우 서버에서 이미지가 변경되지 않은 경우 (status code = 304)
5. cache에 존재하지 않는 경우 

- 2의 경우에는 바로 리턴합니다. 
-  4의 경우에는 디스크 캐시에서 캐싱한 이미지를 메모리 캐시에 저장하고 이미지를 리턴합니다. 
- 1, 3, 5의 경우에는 네트워크 요청으로 얻은 이미지를 디스크, 메모리 캐시에 저장합니다. 


- 특이 사항 2. 
 disk cache는 휘발되지 않아서 캐시 정책으로 관리해줘야 하는데 이건 10주차 쯤 하겠습니다!